### PR TITLE
windows + non-mycroft support

### DIFF
--- a/ovos_plugin_manager/templates/stt.py
+++ b/ovos_plugin_manager/templates/stt.py
@@ -27,7 +27,10 @@ class STT(metaclass=ABCMeta):
             config_stt = config
         self.lang = config_stt.get("lang")
         if not self.lang:
-            config_core = config_core or read_mycroft_config() or {}
+            try:
+                config_core = config_core or read_mycroft_config() or {}
+            except:
+                config_core = config_core or {}
             self.lang = str(self.init_language(config_core))
         self.config = config_stt.get(config_stt.get("module"), {})
         self.credential = self.config.get("credential", {})

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -46,7 +46,7 @@ from ovos_utils.configuration import read_mycroft_config
 EMPTY_PLAYBACK_QUEUE_TUPLE = (None, None, None, None, None)
 
 
-def get_temp_directory(folder):
+def get_cache_directory(folder):
     if os.name == 'nt':
         import tempfile
         return tempfile.mkdtemp(folder)
@@ -223,7 +223,7 @@ class TTS:
         self.ssml_tags = ssml_tags or []
 
         self.voice = self.config.get("voice")
-        self.cache_dir = get_temp_directory(self.tts_name)
+        self.cache_dir = get_cache_directory(self.tts_name)
         self.filename = join(self.cache_dir, 'tts.' + self.audio_ext)
         self.enclosure = None
         random.seed()

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -246,7 +246,11 @@ class TTS:
     def load_spellings(self, config=None):
         """Load phonetic spellings of words as dictionary."""
         path = join('text', self.lang.lower(), 'phonetic_spellings.txt')
-        spellings_file = resolve_resource_file(path, config=config)
+        try:
+            spellings_file = resolve_resource_file(path, config=config)
+        except:
+            LOG.exception('Failed to locate phonetic spellings resouce file.')
+            return {}
         if not spellings_file:
             return {}
         try:


### PR DESCRIPTION
First commit solves the crash when Mycroft-core config is not found, which I think it should be fixed in ovos_utils and not here.
Second commit replaces memory_tempfile with tempfile as the first one is only compatible with Linux systems.

Hopefully ovos_utils gets updated to fix the Mycroft-core config problem and we can discard the first commit.