### PR TITLE
tts lang

### DIFF
--- a/ovos_plugin_manager/stt.py
+++ b/ovos_plugin_manager/stt.py
@@ -22,7 +22,7 @@ class OVOSSTTFactory:
     """ replicates the base mycroft class, but uses only OPM enabled plugins"""
     MAPPINGS = {
         #    "mycroft": MycroftSTT,
-        #    "google": GoogleSTT,
+        "google": "ovos-stt-plugin-chromium",
         #    "google_cloud": GoogleCloudSTT,
         #    "google_cloud_streaming": GoogleCloudStreamingSTT,
         #    "wit": WITSTT,
@@ -35,8 +35,8 @@ class OVOSSTTFactory:
         #    "deepspeech_stream_server": DeepSpeechStreamServerSTT,
         #    "mycroft_deepspeech": MycroftDeepSpeechSTT,
         #    "yandex": YandexSTT
-        "vosk": "vosk_stt_plug",
-        "vosk_streaming": "vosk_streaming_stt_plug"
+        "vosk": "ovos-stt-plugin-vosk",
+        "vosk_streaming": "ovos-stt-plugin-vosk-streaming"
     }
 
     @staticmethod
@@ -51,7 +51,8 @@ class OVOSSTTFactory:
         }
         """
         try:
-            config = config or read_mycroft_config().get("stt", {})
+            config = config or read_mycroft_config()
+            config = config.get("stt", {})
             stt_module = config.get("module", "mycroft")
             if stt_module in OVOSSTTFactory.MAPPINGS:
                 stt_module = OVOSSTTFactory.MAPPINGS[stt_module]

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -439,7 +439,7 @@ class TTS:
                         pass
                 lang = lang or self.lang
                 # check the signature to either pass lang or not
-                if len(signature(self._execute).parameters) == 3:
+                if len(signature(self.get_tts).parameters) == 3:
                     wav_file, phonemes = self.get_tts(sentence, wav_file,
                                                       lang=lang)
                 else:

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -203,6 +203,7 @@ class TTS:
 
     def __init__(self, lang="en-us", config=None, validator=None,
                  audio_ext='wav', phonetic_spelling=True, ssml_tags=None):
+        self.log_timestamps = False
         super(TTS, self).__init__()
         if not config:
             try:

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -19,7 +19,7 @@ def load_tts_plugin(module_name):
     return load_plugin(module_name, PluginTypes.TTS)
 
 
-class OVOSTTFactory:
+class OVOSTTSFactory:
     """ replicates the base mycroft class, but uses only OPM enabled plugins"""
     MAPPINGS = {
         "mimic": "ovos-tts-plugin-mimic",
@@ -59,8 +59,8 @@ class OVOSTTFactory:
         tts_config = config.get('tts', {}).get(tts_module, {})
         tts_lang = tts_config.get('lang', lang)
         try:
-            if tts_module in OVOSTTFactory.MAPPINGS:
-                tts_module = OVOSTTFactory.MAPPINGS[tts_module]
+            if tts_module in OVOSTTSFactory.MAPPINGS:
+                tts_module = OVOSTTSFactory.MAPPINGS[tts_module]
             clazz = load_tts_plugin(tts_module)
             if clazz is None:
                 raise ValueError(f'TTS plugin {tts_module} not found')

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -22,22 +22,22 @@ def load_tts_plugin(module_name):
 class OVOSTTFactory:
     """ replicates the base mycroft class, but uses only OPM enabled plugins"""
     MAPPINGS = {
-        "mimic": "ovos_tts_mimic",
-        "mimic2": "ovos_tts_mimic2",
-        "google": "ovos_tts_google",
+        "mimic": "ovos-tts-plugin-mimic",
+        "mimic2": "ovos-tts-plugin-mimic2",
+        "google": "ovos-tts-plugin-google-tx",
         # "marytts": MaryTTS,
         # "fatts": FATTS,
         # "festival": Festival,
-        "espeak": "espeakNG_tts_plugin",
+        "espeak": "ovos_tts_plugin_espeakng",
         # "spdsay": SpdSay,
         # "watson": WatsonTTS,
         # "bing": BingTTS,
-        "responsive_voice": "responsivevoice_tts_plug",
+        "responsive_voice": "ovos-tts-plugin-responsivevoice",
         # "yandex": YandexTTS,
         "polly": "chatterbox_polly_tts",
         # "mozilla": MozillaTTS,
         # "dummy": DummyTTS
-        "pico": "pico_tts_plugin"
+        "pico": "ovos-tts-plugin-pico"
     }
 
     @staticmethod

--- a/ovos_plugin_manager/wakewords.py
+++ b/ovos_plugin_manager/wakewords.py
@@ -1,4 +1,6 @@
 from ovos_plugin_manager.utils import load_plugin, find_plugins, PluginTypes
+from ovos_utils.configuration import read_mycroft_config
+from ovos_utils.log import LOG
 
 
 def find_wake_word_plugins():
@@ -12,3 +14,37 @@ def load_wake_word_plugin(module_name):
         (str) Mycroft wake word module name from config
     """
     return load_plugin(module_name, PluginTypes.WAKEWORD)
+
+
+class OVOSWakeWordFactory:
+    """ replicates the base mycroft class, but uses only OPM enabled plugins"""
+    MAPPINGS = {
+        "pocketsphinx": "ovos-ww-plugin-pocketsphinx",
+        "precise": "ovos-ww-plugin-precise",
+        "snowboy": "ovos-ww-plugin-snowboy",
+        "porcupine": "porcupine_wakeword_plug"
+    }
+
+    @staticmethod
+    def load_module(module, hotword, config, lang, loop):
+        LOG.info('Loading "{}" wake word via {}'.format(hotword, module))
+        if module in OVOSWakeWordFactory.MAPPINGS:
+            module = OVOSWakeWordFactory.MAPPINGS[module]
+
+        clazz = load_wake_word_plugin(module)
+        if clazz is None:
+            raise ValueError(f'Wake Word plugin {module} not found')
+        LOG.info(
+            'Loaded the Wake Word plugin {}'.format(module))
+
+        return clazz(hotword, config, lang=lang)
+
+    @classmethod
+    def create_hotword(cls, hotword="hey mycroft", config=None,
+                       lang="en-us", loop=None):
+        config = config or read_mycroft_config() or {}
+        config = config.get('hotwords') or config
+        config = config.get(hotword) or config["hey mycroft"]
+
+        module = config.get("module", "pocketsphinx")
+        return cls.load_module(module, hotword, config, lang, loop)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='ovos-plugin-manager',
-    version='0.0.1',
+    version='0.0.1post1',
     packages=['ovos_plugin_manager', 'ovos_plugin_manager.templates'],
     url='https://github.com/OpenVoiceOS/OVOS-plugin-manager',
     license='Apache-2.0',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='ovos-plugin-manager',
-    version='0.0.1a15',
+    version='0.0.1',
     packages=['ovos_plugin_manager', 'ovos_plugin_manager.templates'],
     url='https://github.com/OpenVoiceOS/OVOS-plugin-manager',
     license='Apache-2.0',


### PR DESCRIPTION
adds support the lang parameter when running under HolmesV derivatives, those always go through the `execute` method

also ensures mycroft-style plugins that don't accept lang work

it should not impact standalone usage of plugins (calling `get_tts` directly), those are expected to handle a missing/None lang parameter, its the downstream's code responsibility to ensure things work if using plugins this way, eg, hivemind-voice-satellite passes this lang param on its own accord and skips usage of `execute`, if it loads a plugin that does not accept lang that is out of scope for OPM

this should bring support for neon-core and hivemind