### PR TITLE
Fix Streaming STT Compatibility

### DIFF
--- a/ovos_plugin_manager/templates/stt.py
+++ b/ovos_plugin_manager/templates/stt.py
@@ -132,9 +132,9 @@ class StreamingSTT(STT, metaclass=ABCMeta):
 
     def stream_stop(self):
         if self.stream is not None:
-            text = self.stream.finalize()
             self.queue.put(None)
             self.stream.join()
+            text = self.stream.finalize()
             self.stream = None
             self.queue = None
             return text


### PR DESCRIPTION
Refactor `stream_stop` to make `self.stream.finalize()` call backwards compatible