### PR TITLE
fix/text transformer func names

### DIFF
--- a/ovos_plugin_manager/text_transformers.py
+++ b/ovos_plugin_manager/text_transformers.py
@@ -1,11 +1,11 @@
 from ovos_plugin_manager.utils import load_plugin, find_plugins, PluginTypes
 
 
-def find_text_transformer_plugins():
+def find_utterance_transformer_plugins():
     return find_plugins(PluginTypes.UTTERANCE_TRANSFORMER)
 
 
-def load_text_transformer_plugin(module_name):
+def load_utterance_transformer_plugin(module_name):
     """Wrapper function for loading text_transformer plugin.
 
     Arguments:
@@ -15,3 +15,10 @@ def load_text_transformer_plugin(module_name):
     """
     return load_plugin(module_name, PluginTypes.UTTERANCE_TRANSFORMER)
 
+
+def find_text_transformer_plugins():
+    return find_utterance_transformer_plugins()
+
+
+def load_text_transformer_plugin(module_name):
+    return load_utterance_transformer_plugin(module_name)


### PR DESCRIPTION
text transformers were renamed to utterance transformers in the parent package, this commit adds aliases for the named methods to reflect this change

its only syntactic sugar