### PR TITLE
Remove `SpeechRecognition` dependency for non-STT plugin base classes

### DIFF
--- a/ovos_plugin_manager/templates/stt.py
+++ b/ovos_plugin_manager/templates/stt.py
@@ -6,16 +6,24 @@ The main use case is for plugins to be used across different projects
 """
 import json
 from abc import ABCMeta, abstractmethod
-from speech_recognition import Recognizer
 from queue import Queue
 from threading import Thread, Event
 from ovos_utils.configuration import read_mycroft_config
+
+try:
+    from speech_recognition import Recognizer
+except ImportError:
+    Recognizer = None
 
 
 class STT(metaclass=ABCMeta):
     """ STT Base class, all  STT backends derives from this one. """
 
     def __init__(self, config=None):
+        if not Recognizer:
+            raise ImportError("speech_recognition could not be imported. "
+                              "This can be installed via: "
+                              "`pip install SpeechRecognition")
         config_core = {}
         if not config:
             try:


### PR DESCRIPTION
Make speech_recognition import safe so templates don't carry STT dependencies

Closes #22