### PR TITLE
less logs

### DIFF
--- a/ovos_plugin_manager/g2p.py
+++ b/ovos_plugin_manager/g2p.py
@@ -54,9 +54,8 @@ class OVOSG2PFactory:
         g2p_module = g2p_config.get('module', 'dummy')
         try:
             clazz = OVOSG2PFactory.get_class(g2p_config)
-            LOG.info(f'Found plugin {g2p_module}')
             g2p = clazz(g2p_config)
-            LOG.info(f'Loaded plugin {g2p_module}')
+            LOG.debug(f'Loaded plugin {g2p_module}')
         except Exception:
             LOG.exception('The selected G2P plugin could not be loaded.')
             raise


### PR DESCRIPTION
g2p plugin loader is very noise, and often a dummy plugin

this remove one of the logs and changes the other to debug level