### PR TITLE
feat/tts_context

### DIFF
--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -311,9 +311,8 @@ class KwargParser:
     in that case the helper method get_voice will be used to resolve the final voice_id
     """
 
-    def __init__(self, lang, voice="default"):
-        self.lang = lang
-        self.voice = voice
+    def __init__(self, engine):
+        self.engine = engine
 
     def get_lang(self, kwargs):
         # parse requested language for this TTS request
@@ -326,7 +325,7 @@ class KwargParser:
                        kwargs["message"].context.get("lang")
             except:  # not a mycroft message object
                 pass
-        return lang or self.lang
+        return lang or self.engine.lang
 
     def get_gender(self, kwargs):
         gender = kwargs.get("gender")
@@ -355,9 +354,9 @@ class KwargParser:
             gender = self.get_gender(kwargs)
             if gender:
                 lang = self.get_lang(kwargs)
-                voice = self.get_voice(gender, lang)
+                voice = self.engine.get_voice(gender, lang)
 
-        return voice or self.voice or "default"
+        return voice or self.engine.voice
 
 
 class TTS:
@@ -424,11 +423,8 @@ class TTS:
 
         self.g2p = OVOSG2PFactory.create(config_core)
         self.cache.curate()
+        self.kwarg_parser = KwargParser(self)
         self.add_metric({"metric_type": "tts.init"})
-
-    @property
-    def kwarg_parser(self):
-        return KwargParser(self.lang, self.voice)
 
     @property
     def tts_id(self):

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -725,14 +725,15 @@ class TTS:
         kwargs["lang"] = lang
         kwargs["voice"] = voice
 
+        cache = self.get_cache(voice, lang)  # cache per tts_id (lang/voice combo)
+
         # load from cache
-        if sentence_hash in self.cache:
-            audio, phonemes = self.get_from_cache(sentence, sentence_hash, **kwargs)
+        if sentence_hash in cache:
+            audio, phonemes = self.get_from_cache(sentence, **kwargs)
             self.add_metric({"metric_type": "tts.synth.finished", "cache": True})
             return audio, phonemes
 
         # synth + cache
-        cache = self.get_cache(voice, lang)  # cache per tts_id (lang/voice combo)
         audio = cache.define_audio_file(sentence_hash)
 
         # filter kwargs per plugin, different plugins expose different options
@@ -775,8 +776,8 @@ class TTS:
         cache.cached_sentences[sentence_hash] = (audio_file, pho_file)
         self.add_metric({"metric_type": "tts.synth.cached"})
 
-    def get_from_cache(self, sentence, sentence_hash=None, **kwargs):
-        sentence_hash = sentence_hash or hash_sentence(sentence)
+    def get_from_cache(self, sentence, **kwargs):
+        sentence_hash = hash_sentence(sentence)
         phonemes = None
         lang, voice = self.kwarg_parser.parse(kwargs)
         cache = self.get_cache(voice=voice, lang=lang)

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -362,6 +362,10 @@ class TTSContext:
         kwargs = kwargs or {}
         return self.get_lang(kwargs), self.get_voice(kwargs)
 
+    def get_cache(self, kwargs=None):
+        lang, voice = self.get(kwargs)
+        return self.engine.get_cache(voice, lang)
+
 
 class TTS:
     """TTS abstract class to be implemented by all TTS engines.
@@ -785,8 +789,7 @@ class TTS:
     def get_from_cache(self, sentence, **kwargs):
         sentence_hash = hash_sentence(sentence)
         phonemes = None
-        lang, voice = self.context.get(kwargs)
-        cache = self.get_cache(voice=voice, lang=lang)
+        cache = self.context.get_cache(kwargs)
         audio_file, pho_file = cache.cached_sentences[sentence_hash]
         LOG.info(f"Found {audio_file.name} in TTS cache")
         if not pho_file:

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -358,6 +358,9 @@ class KwargParser:
 
         return voice or self.engine.voice
 
+    def parse(self, kwargs):
+        return self.get_lang(kwargs), self.get_voice(kwargs)
+
 
 class TTS:
     """TTS abstract class to be implemented by all TTS engines.
@@ -718,8 +721,7 @@ class TTS:
 
         # parse requested language for this TTS request
         # NOTE: this is ovos/neon only functionality, not in mycroft-core!
-        lang = self.kwarg_parser.get_lang(kwargs)
-        voice = self.kwarg_parser.get_voice(kwargs)
+        lang, voice = self.kwarg_parser.parse(kwargs)
         kwargs["lang"] = lang
         kwargs["voice"] = voice
 
@@ -776,8 +778,7 @@ class TTS:
     def get_from_cache(self, sentence, sentence_hash=None, **kwargs):
         sentence_hash = sentence_hash or hash_sentence(sentence)
         phonemes = None
-        voice = self.kwarg_parser.get_voice(kwargs)
-        lang = self.kwarg_parser.get_lang(kwargs)
+        lang, voice = self.kwarg_parser.parse(kwargs)
         cache = self.get_cache(voice=voice, lang=lang)
         audio_file, pho_file = cache.cached_sentences[sentence_hash]
         LOG.info(f"Found {audio_file.name} in TTS cache")

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -720,6 +720,13 @@ class TTS:
         self.add_metric({"metric_type": "tts.synth.start"})
         sentence_hash = hash_sentence(sentence)
 
+        # parse requested language for this TTS request
+        # NOTE: this is ovos/neon only functionality, not in mycroft-core!
+        lang = self.kwarg_parser.get_lang(kwargs)
+        voice = self.kwarg_parser.get_voice(kwargs)
+        kwargs["lang"] = lang
+        kwargs["voice"] = voice
+
         # load from cache
         if sentence_hash in self.cache:
             audio, phonemes = self.get_from_cache(sentence, sentence_hash, **kwargs)
@@ -727,14 +734,8 @@ class TTS:
             return audio, phonemes
 
         # synth + cache
-        audio = self.cache.define_audio_file(sentence_hash)
-
-        # parse requested language for this TTS request
-        # NOTE: this is ovos only functionality, not in mycroft-core!
-        lang = self.kwarg_parser.get_lang(kwargs)
-        voice = self.kwarg_parser.get_voice(kwargs)
-        kwargs["lang"] = lang
-        kwargs["voice"] = voice
+        cache = self.get_cache(voice, lang)  # cache per tts_id (lang/voice combo)
+        audio = cache.define_audio_file(sentence_hash)
 
         # filter kwargs per plugin, different plugins expose different options
         #   mycroft-core -> no kwargs


### PR DESCRIPTION
closes #57 

- adds a new method to TTS base class to allow mapping a gender/lang combo to a voice
- refactors kwarg handling into a helper class for simplicity and readability
  - `TTSContext`object now holds all session data logic for requests
       - available as `self.context`
  - adds explicit support for gender keyword 
  - `dig_for_message` is now also used before falling back to default values
- makes `synth`and `get_from_cache` public methods
  - tts-server was using the private methods, companion PR https://github.com/OpenVoiceOS/ovos-tts-server/pull/2
- fix/ makes `self.tts_id` properly session based

## usage

```python

    def get_voice(self, gender, lang=None):
        """ map a language and gender to a valid voice for this TTS engine """
        lang = lang or self.lang
        # return something valid for your plugin here
        voice = gender
        return voice
        
    def get_tts(self, sentence, wav_file, lang=None, voice=None):
        """
            plugins can optionally support arbitrary kwargs
            often lang, voice and gender are sent along in the bus message and will be parsed from there
            any kwarg passed to self.synth or self.execute will be passed along to this method if supported
            self.get_voice method is used internally to map lang/gender combinations to a valid voice
        """

 ```