### PR TITLE
Feat/ui helper

### DIFF
--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -40,12 +40,12 @@ class PluginUIHelper:
         if plugin_type == PluginTypes.STT:
             if not cls._stt_opts and lang:
                 # do initial scan
-                cls.get_display_options(lang, PluginTypes.STT)
+                cls.get_config_options(lang, PluginTypes.STT)
             cls._stt_opts[hash_dict(opt)] = cfg
         elif plugin_type == PluginTypes.TTS:
             if not cls._stt_opts and lang:
                 # do initial scan
-                cls.get_display_options(lang, PluginTypes.TTS)
+                cls.get_config_options(lang, PluginTypes.TTS)
             opt["gender"] = cfg["meta"].get("gender", "?")
             cls._tts_opts[hash_dict(opt)] = cfg
         else:
@@ -74,8 +74,8 @@ class PluginUIHelper:
         return cfg
 
     @classmethod
-    def get_display_options(cls, lang, plugin_type, blacklist=None, preferred=None,
-                            max_opts=20, skip_setup=True, include_dialects=True):
+    def get_config_options(cls, lang, plugin_type, blacklist=None, preferred=None,
+                           max_opts=20, skip_setup=True, include_dialects=True):
         """ return a list of dicts with metadata for downstream UIs
         each option corresponds to a valid selectable plugin configuration, each plugin may report several options
         """
@@ -118,7 +118,7 @@ class PluginUIHelper:
         each entry contains metadata about the plugin and its own options
         """
         plugs = {}
-        for entry in cls.get_display_options(lang, plugin_type):
+        for entry in cls.get_config_options(lang, plugin_type):
             engine = entry["engine"]
             if engine not in plugs:
                 plugs[engine] = {"engine": entry["engine"],

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -43,7 +43,7 @@ class PluginUIHelper:
                 cls.get_config_options(lang, PluginTypes.STT)
             cls._stt_opts[hash_dict(opt)] = cfg
         elif plugin_type == PluginTypes.TTS:
-            if not cls._stt_opts and lang:
+            if not cls._tts_opts and lang:
                 # do initial scan
                 cls.get_config_options(lang, PluginTypes.TTS)
             opt["gender"] = cfg["meta"].get("gender", "?")

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -97,9 +97,11 @@ class PluginUIHelper:
             pref_opts = []
             for config in configs:
                 config = cls._migrate_old_cfg(config)
-                if config["meta"].get("extra_setup") and skip_setup:
-                    # this config requires additional manual setup, skip was requested
-                    continue
+                if config["meta"].get("extra_setup"):
+                    optional = config["meta"]["extra_setup"].get("optional")
+                    if not optional and skip_setup:
+                        # this config requires additional manual setup, skip was requested
+                        continue
                 config["module"] = engine  # this one should be ensured by get_lang_configs, but just in case
                 d = cls.config2option(config, plugin_type, lang)
                 if preferred and preferred not in blacklist and preferred == engine:

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -36,7 +36,8 @@ class PluginUIHelper:
                "display_name": display_name,
                "offline": offline,
                "lang": lang,
-               "engine": engine}
+               "engine": engine,
+               "plugin_type": plugin_type}
 
         if plugin_type == PluginTypes.STT:
             if not cls._stt_opts and lang:
@@ -54,8 +55,11 @@ class PluginUIHelper:
         return opt
 
     @classmethod
-    def option2config(cls, opt, plugin_type):
+    def option2config(cls, opt, plugin_type=None):
         """ get the equivalent plugin config from a UI display model """
+        plugin_type = plugin_type or opt.get("plugin_type")
+        if not plugin_type:
+            raise ValueError("Unknown plugin type")
         if plugin_type == PluginTypes.STT:
             cfg = dict(cls._stt_opts.get(hash_dict(opt)))
         elif plugin_type == PluginTypes.TTS:
@@ -149,7 +153,7 @@ class PluginUIHelper:
         return flatten_list(plugs.values())
 
     @classmethod
-    def get_extra_setup(cls, opt, plugin_type):
+    def get_extra_setup(cls, opt, plugin_type=None):
         """
         individual plugins can provide a equivalent structure to skills settingsmeta.json/yaml
         this can be used to display an extra step for plugin configuration,
@@ -159,5 +163,8 @@ class PluginUIHelper:
         arbitrary configurations to downstream UIs,
         with selene being the reference consumer of that api
         """
+        plugin_type = plugin_type or opt.get("plugin_type")
+        if not plugin_type:
+            raise ValueError("Unknown plugin type")
         meta = cls.option2config(opt, plugin_type)["meta"]
         return meta.get("extra_setup") or {}

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -80,7 +80,7 @@ class PluginUIHelper:
 
     @classmethod
     def get_config_options(cls, lang, plugin_type, blacklist=None, preferred=None,
-                           max_opts=20, skip_setup=True, include_dialects=True):
+                           max_opts=50, skip_setup=True, include_dialects=True):
         """ return a list of dicts with metadata for downstream UIs
         each option corresponds to a valid selectable plugin configuration, each plugin may report several options
         """
@@ -88,6 +88,9 @@ class PluginUIHelper:
         # TODO - validate that this is true and 20 is a real limit
         blacklist = blacklist or []
         opts = []
+        preferred = preferred or []
+        if isinstance(preferred, str):
+            preferred = [preferred]
         if plugin_type == PluginTypes.STT:
             cfgs = get_stt_lang_configs(lang=lang, include_dialects=include_dialects)
         elif plugin_type == PluginTypes.TTS:
@@ -108,7 +111,7 @@ class PluginUIHelper:
                         continue
                 config["module"] = engine  # this one should be ensured by get_lang_configs, but just in case
                 d = cls.config2option(config, plugin_type, lang)
-                if preferred and preferred not in blacklist and preferred == engine:
+                if engine in preferred:
                     # Sort the list for UI to display the preferred STT engine first
                     # allow images to set a preferred engine
                     pref_opts.append(d)

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -1,5 +1,5 @@
 import json
-
+from ovos_utils import flatten_list
 from ovos_plugin_manager import PluginTypes
 from ovos_plugin_manager.stt import get_stt_lang_configs
 from ovos_plugin_manager.tts import get_tts_lang_configs
@@ -10,7 +10,8 @@ def hash_dict(d):
 
 
 class PluginUIHelper:
-    """ Helper class to provide metadata for UI consumption
+    """
+    Helper class to provide metadata for UI consumption
     This allows all sorts of rich integrations by
     any downstream application wanting to provide a plugin store
 
@@ -143,7 +144,7 @@ class PluginUIHelper:
 
             plugs[engine]["options"].append(entry)
 
-        return list(plugs.values())
+        return flatten_list(plugs.values())
 
     @classmethod
     def get_extra_setup(cls, opt, plugin_type):

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -51,6 +51,7 @@ class PluginUIHelper:
                 if engine in blacklist:
                     continue
                 for config in configs:
+                    config["module"] = engine
                     d = cls.stt_config2option(config, lang)
                     if preferred and preferred not in blacklist and preferred == engine:
                         # Sort the list for UI to display the preferred STT engine first
@@ -96,6 +97,7 @@ class PluginUIHelper:
                 if engine in blacklist:
                     continue
                 for voice in configs:
+                    voice["module"] = engine
                     d = cls.tts_config2option(voice, lang)
                     if preferred and preferred not in blacklist and preferred == engine:
                         # Sort the list for UI to display the preferred TTS engine first

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -114,7 +114,7 @@ class PluginUIHelper:
 
     @classmethod
     def get_plugin_options(cls, lang, plugin_type):
-        """return a dict of {plugin_name: [options]} for UI display
+        """return a list of dicts with individual plugin metadata for UI display
         each entry contains metadata about the plugin and its own options
         """
         plugs = {}
@@ -143,7 +143,7 @@ class PluginUIHelper:
 
             plugs[engine]["options"].append(entry)
 
-        return plugs
+        return list(plugs.values())
 
     @classmethod
     def get_extra_setup(cls, opt, plugin_type):

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -79,7 +79,7 @@ class PluginUIHelper:
         elif plugin_type == PluginTypes.TTS:
             cfgs = get_tts_lang_configs(lang=lang, include_dialects=True)
         else:
-            raise NotImplementedError
+            raise NotImplementedError("only STT and TTS plugins are supported at this time")
 
         for engine, configs in cfgs.items():
             if engine in blacklist:

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -39,8 +39,14 @@ class PluginUIHelper:
                "engine": engine}
 
         if plugin_type == PluginTypes.STT:
+            if not cls._stt_opts and lang:
+                # do initial scan
+                cls.get_display_options(lang, PluginTypes.STT)
             cls._stt_opts[hash_dict(opt)] = cfg
         elif plugin_type == PluginTypes.TTS:
+            if not cls._stt_opts and lang:
+                # do initial scan
+                cls.get_display_options(lang, PluginTypes.TTS)
             opt["gender"] = cfg["meta"].get("gender", "?")
             cls._tts_opts[hash_dict(opt)] = cfg
         else:
@@ -91,7 +97,7 @@ class PluginUIHelper:
                 if config["meta"].get("extra_setup") and skip_setup:
                     # this config requires additional manual setup, skip was requested
                     continue
-                config["module"] = engine  # this one should be ensurec by get_lang_configs, but just in case
+                config["module"] = engine  # this one should be ensured by get_lang_configs, but just in case
                 d = cls.config2option(config, plugin_type, lang)
                 if preferred and preferred not in blacklist and preferred == engine:
                     # Sort the list for UI to display the preferred STT engine first

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -121,10 +121,10 @@ class PluginUIHelper:
             return []
 
     @classmethod
-    def get_extra_settings(cls, opt, plugin_type):
+    def get_extra_setup(cls, opt, plugin_type):
         """ this method is a placeholder and currently returns only a empty dict
 
-        TODO - skills already define a settingsmeta.json/yaml structure
+        skills already define a settingsmeta.json/yaml structure
         that allows exposing arbitrary configurations to downstream UIs,
         with selene being the reference consumer of that api
         individual plugins should be able to provide a equivalent structure
@@ -132,9 +132,5 @@ class PluginUIHelper:
         such as required api keys that cant be pre-included by plugins
 
         """
-        engine = opt["engine"]
-        if plugin_type == PluginTypes.STT:
-            pass
-        elif plugin_type == PluginTypes.TTS:
-            pass
-        return {}
+        meta = cls.option2config(opt, plugin_type)["meta"]
+        return meta.get("extra_setup") or {}

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -1,0 +1,111 @@
+import json
+
+from ovos_utils.log import LOG
+
+from ovos_plugin_manager.stt import get_stt_lang_configs
+from ovos_plugin_manager.tts import get_tts_lang_configs
+
+
+def hash_dict(d):
+    return str(hash(json.dumps(d, indent=2, sort_keys=True, ensure_ascii=True)))
+
+
+class PluginUIHelper:
+    """ Helper class to provide metadata for UI consumption
+    This allows all sorts of rich integrations by
+    any downstream application wanting to provide a plugin store
+
+    This is the central place to manage anything UI related,
+    downstream should not need to import anything else
+    """
+    _stt_opts = {}
+    _tts_opts = {}
+
+    @classmethod
+    def stt_option2config(cls, opt):
+        """ get the equivalent plugin config from a UI display model """
+        return cls._stt_opts.get(hash_dict(opt))
+
+    @classmethod
+    def stt_config2option(cls, cfg, lang=None):
+        """ get the equivalent UI display model from a plugin config """
+        engine = cfg["module"]
+        lang = lang or cfg.get("lang")
+        plugin_display_name = engine.replace("_", " ").replace("-", " ").title()
+        opt = {"plugin_name": plugin_display_name,
+               "display_name": cfg.get("display_name", " "),
+               "offline": cfg.get("offline", False),
+               "lang": lang,
+               "engine": engine}
+        cls._stt_opts[hash_dict(opt)] = cfg
+        return opt
+
+    @classmethod
+    def get_stt_display_options(cls, lang, blacklist=None, preferred=None, max_opts=20):
+        # NOTE: mycroft-gui will crash if theres more than 20 options according to @aiix
+        try:
+            blacklist = blacklist or []
+            stt_opts = []
+            cfgs = get_stt_lang_configs(lang=lang, include_dialects=True)
+            for engine, configs in cfgs.items():
+                if engine in blacklist:
+                    continue
+                for config in configs:
+                    d = cls.stt_config2option(config, lang)
+                    if preferred and preferred not in blacklist and preferred == engine:
+                        # Sort the list for UI to display the preferred STT engine first
+                        # allow images to set a preferred engine
+                        stt_opts.insert(0, d)
+                    else:
+                        stt_opts.append(d)
+            return stt_opts[:max_opts]
+        except Exception as e:
+            LOG.error(e)
+            # Return an empty list if there is an error
+            # UI will handle this and display an error message
+            return []
+
+    @classmethod
+    def tts_option2config(cls, opt):
+        """ get the equivalent plugin config from a UI display model"""
+        return cls._tts_opts.get(hash_dict(opt))
+
+    @classmethod
+    def tts_config2option(cls, cfg, lang=None):
+        """ get the equivalent UI display model from a tts plugin config"""
+        engine = cfg["module"]
+        lang = lang or cfg.get("lang")
+        plugin_display_name = engine.replace("_", " ").replace("-", " ").title()
+        opt = {"plugin_name": plugin_display_name,
+               "display_name": cfg.get("display_name", " "),
+               "gender": cfg.get("gender", " "),
+               "offline": cfg.get("offline", False),
+               "lang": lang,
+               "engine": engine}
+        cls._tts_opts[hash_dict(opt)] = cfg
+        return opt
+
+    @classmethod
+    def get_tts_display_options(cls, lang, blacklist=None, preferred=None, max_opts=20):
+        # NOTE: mycroft-gui will crash if theres more than 20 options according to @aiix
+        try:
+            blacklist = blacklist or []
+            tts_opts = []
+            cfgs = get_tts_lang_configs(lang=lang, include_dialects=True)
+            for engine, configs in cfgs.items():
+                if engine in blacklist:
+                    continue
+                for voice in configs:
+                    d = cls.tts_config2option(voice, lang)
+                    if preferred and preferred not in blacklist and preferred == engine:
+                        # Sort the list for UI to display the preferred TTS engine first
+                        # allow images to set a preferred engine
+                        tts_opts.insert(0, d)
+                    else:
+                        tts_opts.append(d)
+            return tts_opts[:max_opts]
+        except Exception as e:
+            LOG.error(e)
+            # Return an empty list if there is an error
+            # UI will handle this and display an error message
+            return []

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -69,15 +69,16 @@ class PluginUIHelper:
         return cfg
 
     @classmethod
-    def get_display_options(cls, lang, plugin_type, blacklist=None, preferred=None, max_opts=20, skip_setup=True):
+    def get_display_options(cls, lang, plugin_type, blacklist=None, preferred=None,
+                            max_opts=20, skip_setup=True, include_dialects=True):
         # NOTE: mycroft-gui will crash if theres more than 20 options according to @aiix
         # TODO - validate that this is true and 20 is a real limit
         blacklist = blacklist or []
         opts = []
         if plugin_type == PluginTypes.STT:
-            cfgs = get_stt_lang_configs(lang=lang, include_dialects=True)
+            cfgs = get_stt_lang_configs(lang=lang, include_dialects=include_dialects)
         elif plugin_type == PluginTypes.TTS:
-            cfgs = get_tts_lang_configs(lang=lang, include_dialects=True)
+            cfgs = get_tts_lang_configs(lang=lang, include_dialects=include_dialects)
         else:
             raise NotImplementedError("only STT and TTS plugins are supported at this time")
 

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -86,7 +86,7 @@ class PluginUIHelper:
                     continue
                 for config in configs:
                     config = cls._migrate_old_cfg(config)
-                    if config.get("meta", {}).get("extra_setup") and skip_setup:
+                    if config["meta"].get("extra_setup") and skip_setup:
                         # this config requires additional manual setup, skip was requested
                         continue
                     config["module"] = engine  # this one should be ensurec by get_lang_configs, but just in case
@@ -106,15 +106,14 @@ class PluginUIHelper:
 
     @classmethod
     def get_extra_setup(cls, opt, plugin_type):
-        """ this method is a placeholder and currently returns only a empty dict
-
-        skills already define a settingsmeta.json/yaml structure
-        that allows exposing arbitrary configurations to downstream UIs,
-        with selene being the reference consumer of that api
-        individual plugins should be able to provide a equivalent structure
+        """
+        individual plugins can provide a equivalent structure to skills settingsmeta.json/yaml
         this can be used to display an extra step for plugin configuration,
         such as required api keys that cant be pre-included by plugins
 
+        skills already define this data structure that allows exposing
+        arbitrary configurations to downstream UIs,
+        with selene being the reference consumer of that api
         """
         meta = cls.option2config(opt, plugin_type)["meta"]
         return meta.get("extra_setup") or {}


### PR DESCRIPTION
add a new class for consumption by downstream appstore like integrations

companion PR in setup skill https://github.com/OpenVoiceOS/skill-ovos-setup/pull/57

This new class is the central place to manage anything UI related,  downstream should not need to import anything else
    
This allows all sorts of rich integrations by any downstream application, terminal, web, GUI...
    
initial implementation only for stt and tts, extracted from setup skill. future PRs will add other kinds of plugins

plugin configs are now expected to move UI specific data to a "meta" section, backwards compatibility is provided for existing keys in the wild, this also introduces the concept of an equivalent to skills settingsmeta.json to request additional setup steps

the intention is that this can be directly integrated with this sort of UI https://github.com/MycroftAI/mycroft-core/pull/2698 

side note, there are utils to generate settings meta from dicts automatically, this can be used to share the UI for editing mycroft.conf with some extra work for handling edge cases