### PR TITLE
Resolve setup skill errors

### DIFF
--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -176,9 +176,13 @@ class PluginUIHelper:
         return opts[:min(max_opts, len(opts))]
 
     @classmethod
-    def get_plugin_options(cls, lang, plugin_type):
-        """return a list of dicts with individual plugin metadata for UI display
-        each entry contains metadata about the plugin and its own options
+    def get_plugin_options(cls, lang: str, plugin_type: PluginTypes) -> list:
+        """
+        Get a list of dict metadata for downstream UIs.
+        Each option corresponds to a valid plugin and its capabilities
+        @param lang: Requested language (ISO 639-1 or BCP-47)
+        @param plugin_type: Type of plugins to return
+        @return: list of plugin specs with capabilities and config options
         """
         plugs = {}
         for entry in cls.get_config_options(lang, plugin_type):
@@ -206,7 +210,7 @@ class PluginUIHelper:
 
             plugs[engine]["options"].append(entry)
 
-        return flatten_list(plugs.values())
+        return flatten_list(list(plugs.values()))
 
     @classmethod
     def get_extra_setup(cls, opt, plugin_type=None):

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -1,5 +1,6 @@
 import json
 from ovos_utils import flatten_list
+from ovos_utils.log import LOG
 from ovos_plugin_manager import PluginTypes
 from ovos_plugin_manager.stt import get_stt_lang_configs
 from ovos_plugin_manager.tts import get_tts_lang_configs
@@ -98,6 +99,7 @@ class PluginUIHelper:
         else:
             raise NotImplementedError("only STT and TTS plugins are supported at this time")
 
+        LOG.debug(f"cfgs={cfgs}")
         for engine, configs in cfgs.items():
             if engine in blacklist:
                 continue
@@ -120,7 +122,8 @@ class PluginUIHelper:
 
             # artificially send preferred engine entries to start of list
             opts = pref_opts + opts
-            return opts[:max_opts]
+        LOG.debug(f"Got {len(opts)} opts")
+        return opts[:min(max_opts, len(opts))]
 
     @classmethod
     def get_plugin_options(cls, lang, plugin_type):

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -83,7 +83,7 @@ class PluginUIHelper:
         This is the inverse of config2option.
         @param opt: Configuration from GUI
         @param plugin_type: Plugin type (stt/tts)
-        @return: default core configuration for requested opt
+        @return: plugin configuration for requested opt (lang, meta, module)
         """
         plugin_type = plugin_type or opt.get("plugin_type")
         if not plugin_type:

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -41,12 +41,12 @@ class PluginUIHelper:
                "plugin_type": plugin_type}
 
         if plugin_type == PluginTypes.STT:
-            if not cls._stt_opts and lang:
+            if lang and not cls._stt_opts:
                 # do initial scan
                 cls.get_config_options(lang, PluginTypes.STT)
             cls._stt_opts[hash_dict(opt)] = cfg
         elif plugin_type == PluginTypes.TTS:
-            if not cls._tts_opts and lang:
+            if lang and not cls._tts_opts:
                 # do initial scan
                 cls.get_config_options(lang, PluginTypes.TTS)
             opt["gender"] = cfg["meta"].get("gender", "?")

--- a/ovos_plugin_manager/utils/ui.py
+++ b/ovos_plugin_manager/utils/ui.py
@@ -213,7 +213,9 @@ class PluginUIHelper:
 
             plugs[engine]["options"].append(entry)
 
-        return flatten_list(list(plugs.values()))
+        opts = flatten_list(list(plugs.values()))
+        LOG.debug(opts)
+        return opts
 
     @classmethod
     def get_extra_setup(cls, opt: dict,

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -758,20 +758,23 @@ class TestUiUtils(unittest.TestCase):
         from ovos_plugin_manager.utils.ui import PluginUIHelper, PluginTypes, \
             hash_dict
 
-        plugin_config = {'lang': 'en-US',
-                         'module': 'google_cloud_streaming',
-                         'meta': {'display_name': 'English (United States)',
-                                  'offline': False,
-                                  'priority': 75}}
+        valid_opt = {'plugin_name': 'Deepspeech Stream Local',
+                     'display_name': 'English (en-US)',
+                     'offline': True,
+                     'lang': 'en',
+                     'engine': 'deepspeech_stream_local',
+                     'plugin_type': PluginTypes.STT}
 
         # Init STT configurations
-        valid_opt = PluginUIHelper.config2option(deepcopy(plugin_config),
-                                                 PluginTypes.STT, 'en')
+        opts = PluginUIHelper.get_config_options('en', PluginTypes.STT)
+        self.assertIn(valid_opt, opts)
+        self.assertTrue(PluginUIHelper._stt_init)
+        self.assertIsNotNone(PluginUIHelper._stt_opts)
+
+        # Validate config
         self.assertIsInstance(PluginUIHelper._stt_opts[hash_dict(valid_opt)],
                               dict)
 
         # Get config out
         config = PluginUIHelper.option2config(valid_opt, PluginTypes.STT)
-        self.assertEqual(config, plugin_config)
-        config = PluginUIHelper.option2config(valid_opt)
-        self.assertEqual(config, plugin_config)
+        self.assertEqual(set(config.keys()), {'lang', 'meta', 'module'})

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import deepcopy
 from unittest.mock import patch
 
 _MOCK_CONFIG = {
@@ -617,7 +618,7 @@ class TestUiUtils(unittest.TestCase):
 
     @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
     def test_get_config_options(self, get_stt_lang_configs):
-        get_stt_lang_configs.return_value = _MOCK_VALID_PLUGINS_CONFIG
+        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
         import importlib
         import ovos_plugin_manager.utils.ui
         importlib.reload(ovos_plugin_manager.utils.ui)

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -396,7 +396,7 @@ _MOCK_PLUGIN_CONFIG = {
                'offline': False,
                'priority': 60}]}
 
-_MOCK_VALID_PLUGINS_CONFIG = {
+_MOCK_VALID_STT_PLUGINS_CONFIG = {
     'deepspeech_stream_local': [{'display_name': 'English (en-US)',
                                  'lang': 'en-US',
                                  'offline': True,
@@ -556,7 +556,7 @@ class TestConfigUtils(unittest.TestCase):
 
     def test_sort_plugin_configs(self):
         from ovos_plugin_manager.utils.config import sort_plugin_configs
-        sorted_configs = sort_plugin_configs(_MOCK_VALID_PLUGINS_CONFIG)
+        sorted_configs = sort_plugin_configs(_MOCK_VALID_STT_PLUGINS_CONFIG)
 
         self.assertEqual(sorted_configs['google_cloud_streaming'][-1],
                          {'display_name': 'English (United States)',
@@ -604,7 +604,7 @@ class TestUiUtils(unittest.TestCase):
 
     def test_plugin_ui_helper_migrate_old_cfg(self):
         from ovos_plugin_manager.utils.ui import PluginUIHelper
-        old_cfg = _MOCK_VALID_PLUGINS_CONFIG['deepspeech_stream_local'][0]
+        old_cfg = _MOCK_VALID_STT_PLUGINS_CONFIG['deepspeech_stream_local'][0]
         new_cfg = PluginUIHelper._migrate_old_cfg(old_cfg)
         self.assertEqual(new_cfg, {'lang': 'en-US',
                                    'meta': {
@@ -618,8 +618,8 @@ class TestUiUtils(unittest.TestCase):
         self.assertEqual(new_cfg, new_new_cfg)
 
     @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
-    def test_plugin_ui_helper_get_config_options(self, get_stt_lang_configs):
-        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
+    def test_plugin_ui_helper_get_config_options_STT(self, get_stt_lang_configs):
+        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_STT_PLUGINS_CONFIG)
         import importlib
         import ovos_plugin_manager.utils.ui
         importlib.reload(ovos_plugin_manager.utils.ui)
@@ -628,7 +628,7 @@ class TestUiUtils(unittest.TestCase):
 
         flat_valid_configs = list()
         [flat_valid_configs.extend(cfg) for
-         cfg in _MOCK_VALID_PLUGINS_CONFIG.values()]
+         cfg in _MOCK_VALID_STT_PLUGINS_CONFIG.values()]
 
         self.assertFalse(PluginUIHelper._stt_init)
         self.assertFalse(PluginUIHelper._tts_init)
@@ -665,8 +665,8 @@ class TestUiUtils(unittest.TestCase):
         self.assertEqual(len(stt_opts), 5)
 
     @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
-    def test_plugin_ui_helper_get_plugin_options(self, get_stt_lang_configs):
-        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
+    def test_plugin_ui_helper_get_plugin_options_STT(self, get_stt_lang_configs):
+        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_STT_PLUGINS_CONFIG)
         import importlib
         import ovos_plugin_manager.utils.ui
         importlib.reload(ovos_plugin_manager.utils.ui)
@@ -675,7 +675,7 @@ class TestUiUtils(unittest.TestCase):
         stt_plugins = PluginUIHelper.get_plugin_options('en', PluginTypes.STT)
         self.assertIsInstance(stt_plugins, list)
         self.assertEqual(len(stt_plugins),
-                         len([p for p in _MOCK_VALID_PLUGINS_CONFIG.values()
+                         len([p for p in _MOCK_VALID_STT_PLUGINS_CONFIG.values()
                               if p]))
         for plug in stt_plugins:
             self.assertEqual(set(plug.keys()), {'engine', 'plugin_name',
@@ -694,8 +694,8 @@ class TestUiUtils(unittest.TestCase):
                                   'lang', 'engine', 'plugin_type'})
 
     @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
-    def test_plugin_ui_helper_get_extra_setup(self, get_stt_lang_configs):
-        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
+    def test_plugin_ui_helper_get_extra_setup_STT(self, get_stt_lang_configs):
+        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_STT_PLUGINS_CONFIG)
         import importlib
         import ovos_plugin_manager.utils.ui
         importlib.reload(ovos_plugin_manager.utils.ui)
@@ -707,8 +707,8 @@ class TestUiUtils(unittest.TestCase):
                 PluginUIHelper.get_extra_setup(opt, PluginTypes.STT), dict)
 
     @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
-    def test_plugin_ui_helper_config2option(self, get_stt_lang_configs):
-        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
+    def test_plugin_ui_helper_config2option_STT(self, get_stt_lang_configs):
+        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_STT_PLUGINS_CONFIG)
         import importlib
         import ovos_plugin_manager.utils.ui
         importlib.reload(ovos_plugin_manager.utils.ui)
@@ -750,8 +750,8 @@ class TestUiUtils(unittest.TestCase):
                          PluginUIHelper._stt_opts[hash_dict(new_opt)])
 
     @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
-    def test_plugin_ui_helper_option2config(self, get_stt_lang_configs):
-        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
+    def test_plugin_ui_helper_option2config_STT(self, get_stt_lang_configs):
+        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_STT_PLUGINS_CONFIG)
         import importlib
         import ovos_plugin_manager.utils.ui
         importlib.reload(ovos_plugin_manager.utils.ui)
@@ -778,3 +778,5 @@ class TestUiUtils(unittest.TestCase):
         # Get config out
         config = PluginUIHelper.option2config(valid_opt, PluginTypes.STT)
         self.assertEqual(set(config.keys()), {'lang', 'meta', 'module'})
+
+    # TODO: Duplicate STT tests for TTS

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -617,7 +617,7 @@ class TestUiUtils(unittest.TestCase):
         self.assertEqual(new_cfg, new_new_cfg)
 
     @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
-    def test_get_config_options(self, get_stt_lang_configs):
+    def test_plugin_ui_helper_get_config_options(self, get_stt_lang_configs):
         get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
         import importlib
         import ovos_plugin_manager.utils.ui
@@ -662,3 +662,32 @@ class TestUiUtils(unittest.TestCase):
         stt_opts = PluginUIHelper.get_config_options('en', PluginTypes.STT,
                                                      max_opts=5)
         self.assertEqual(len(stt_opts), 5)
+
+    @patch("ovos_plugin_manager.stt.get_stt_lang_configs")
+    def test_plugin_ui_helper_get_plugin_options(self, get_stt_lang_configs):
+        get_stt_lang_configs.return_value = deepcopy(_MOCK_VALID_PLUGINS_CONFIG)
+        import importlib
+        import ovos_plugin_manager.utils.ui
+        importlib.reload(ovos_plugin_manager.utils.ui)
+        from ovos_plugin_manager.utils.ui import PluginUIHelper, PluginTypes
+
+        stt_plugins = PluginUIHelper.get_plugin_options('en', PluginTypes.STT)
+        self.assertIsInstance(stt_plugins, list)
+        self.assertEqual(len(stt_plugins),
+                         len([p for p in _MOCK_VALID_PLUGINS_CONFIG.values()
+                              if p]))
+        for plug in stt_plugins:
+            self.assertEqual(set(plug.keys()), {'engine', 'plugin_name',
+                                                'supports_offline_mode',
+                                                'supports_online_mode',
+                                                'options'})
+            self.assertIsInstance(plug['engine'], str)
+            self.assertIsInstance(plug['plugin_name'], str)
+            self.assertIsInstance(plug['supports_offline_mode'], bool)
+            self.assertIsInstance(plug['supports_online_mode'], bool)
+            self.assertIsInstance(plug['options'], list)
+            for opt in plug['options']:
+                self.assertIsInstance(opt, dict)
+                self.assertEqual(set(opt.keys()),
+                                 {'plugin_name', 'display_name', 'offline',
+                                  'lang', 'engine', 'plugin_type'})


### PR DESCRIPTION
Resolves setup skill errors as noted in latest Neon and Buildroot images. Minimal refactoring of changes from #85 with added unit tests and updated docstrings