### PR TITLE
fix/plugin_config

### DIFF
--- a/ovos_plugin_manager/utils/config.py
+++ b/ovos_plugin_manager/utils/config.py
@@ -22,7 +22,8 @@ def get_plugin_config(config: Optional[dict] = None, section: str = None,
         module_config.setdefault('lang', lang)
         module_config.setdefault('module', module)
         return module_config
-    config.setdefault('lang', lang)
+    if section not in ["hotwords", "VAD", "listener"]:
+        config.setdefault('lang', lang)
     return config
 
 


### PR DESCRIPTION
"lang" was wrongly added to some configs, causes issues such as trying to load invalid wakeword `"lang": "en-us"`