### PR TITLE
feat/ww fallback

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -49,3 +49,7 @@ jobs:
         run: |
           pip install .
       - uses: pypa/gh-action-pip-audit@v1.0.0
+        with:
+          # Ignore setuptools vulnerability we can't do much about
+          ignore-vulns: |
+            GHSA-r9hx-vwmv-q579

--- a/ovos_plugin_manager/wakewords.py
+++ b/ovos_plugin_manager/wakewords.py
@@ -97,7 +97,7 @@ class OVOSWakeWordFactory:
     def create_hotword(cls, hotword="hey mycroft", config=None,
                        lang="en-us", loop=None):
         ww_configs = get_hotwords_config(config)
-        ww_config = ww_configs.get(hotword) or ww_configs.get("hey mycroft")
+        ww_config = ww_configs.get(hotword) or ww_configs.get("hey_mycroft")
         module = ww_config.get("module", "pocketsphinx")
         try:
             return cls.load_module(module, hotword, ww_config, lang, loop)

--- a/ovos_plugin_manager/wakewords.py
+++ b/ovos_plugin_manager/wakewords.py
@@ -96,13 +96,17 @@ class OVOSWakeWordFactory:
     @classmethod
     def create_hotword(cls, hotword="hey mycroft", config=None,
                        lang="en-us", loop=None):
-        config = get_hotwords_config(config)
-        config = config.get(hotword) or config["hey mycroft"]
-        module = config.get("module", "pocketsphinx")
+        ww_configs = get_hotwords_config(config)
+        ww_config = ww_configs.get(hotword) or ww_configs.get("hey mycroft")
+        module = ww_config.get("module", "pocketsphinx")
         try:
-            return cls.load_module(module, hotword, config, lang, loop)
+            return cls.load_module(module, hotword, ww_config, lang, loop)
         except:
-            LOG.error(f"failed to created hotword: {config}")
+            LOG.error(f"Failed to load hotword: {hotword} - {module}")
+            fallback_ww = ww_config.get("fallback_ww")
+            if fallback_ww in ww_configs and fallback_ww != hotword:
+                LOG.info(f"Attempting to load fallback ww instead: {fallback_ww}")
+                return cls.create_hotword(fallback_ww, config, lang, loop)
             raise
 
 


### PR DESCRIPTION
allow hotword config to specify alternative ww to load on failure, this allows to recursively specify plugins in config and load the best one available

```javascript
    "hey_mycroft": {
        "module": "ovos-ww-plugin-precise-lite",
        "model": "https://github.com/OpenVoiceOS/precise-lite-models/raw/master/wakewords/en/hey_mycroft.tflite",
        "expected_duration": 3,
        "trigger_level": 3,
        "sensitivity": 0.5,
        "listen": true,
        "fallback_ww": "hey_mycroft_precise"
    },
    "hey_mycroft_precise": {
        "module": "ovos-ww-plugin-precise",
        "version": "0.3",
        "model": "https://github.com/MycroftAI/precise-data/raw/models-dev/hey-mycroft.tar.gz",
        "expected_duration": 3,
        "trigger_level": 3,
        "sensitivity": 0.5,
        "listen": true,
        "fallback_ww": "hey_mycroft_vosk"
    },
    "hey_mycroft_vosk": {
        "module": "ovos-ww-plugin-vosk",
        "samples": ["hey mycroft", "hey microsoft", "hey mike roft", "hey minecraft"],
        "rule": "fuzzy",
        "listen": true,
        "fallback_ww": "hey_mycroft_pocketsphinx"
    },
    "hey_mycroft_pocketsphinx": {
        "module": "ovos-ww-plugin-pocketsphinx",
        "phonemes": "HH EY . M AY K R AO F T",
        "threshold": 1e-90,
        "lang": "en-us",
        "listen": true
    }
```