### PR TITLE
fix/dummy_stt_plugin

### DIFF
--- a/ovos_plugin_manager/templates/stt.py
+++ b/ovos_plugin_manager/templates/stt.py
@@ -99,7 +99,6 @@ class STT(metaclass=ABCMeta):
             return langs[0].lower() + "-" + langs[1].upper()
         return lang
 
-    @abstractmethod
     def execute(self, audio, language=None):
         pass
 


### PR DESCRIPTION
"dummy" stt plugin failed to load because of abstractmethod