### PR TITLE
Update `get_plugin_config` and tests for GUI support

### DIFF
--- a/ovos_plugin_manager/gui.py
+++ b/ovos_plugin_manager/gui.py
@@ -100,7 +100,7 @@ class OVOSGuiFactory:
         }
         """
         gui_config = get_gui_config(config)
-        gui_module = gui_config.get('extension', 'generic')
+        gui_module = gui_config.get('module', 'generic')
         try:
             clazz = OVOSGuiFactory.get_class(gui_config)
             gui = clazz(gui_config, bus=bus, gui=gui)

--- a/ovos_plugin_manager/gui.py
+++ b/ovos_plugin_manager/gui.py
@@ -71,6 +71,11 @@ def get_gui_config(config: Optional[dict] = None) -> dict:
 
 
 class OVOSGuiFactory:
+    MAPPINGS = {
+        "smartspeaker": "ovos-gui-plugin-shell-companion",
+        "bigscreen": "ovos-gui-plugin-bigscreen"
+    }
+
     @staticmethod
     def get_class(config=None):
         """Factory method to get a gui engine class based on configuration.
@@ -84,6 +89,8 @@ class OVOSGuiFactory:
         """
         config = get_gui_config(config)
         gui_module = config.get("module") or 'generic'
+        if gui_module in OVOSGuiFactory.MAPPINGS:
+            gui_module = OVOSGuiFactory.MAPPINGS[gui_module]
         if gui_module == 'generic':
             return GUIExtension
         return load_gui_plugin(gui_module)

--- a/ovos_plugin_manager/gui.py
+++ b/ovos_plugin_manager/gui.py
@@ -71,11 +71,6 @@ def get_gui_config(config: Optional[dict] = None) -> dict:
 
 
 class OVOSGuiFactory:
-    MAPPINGS = {
-        "smartspeaker": "ovos-gui-plugin-shell-companion",
-        "bigscreen": "ovos-gui-plugin-bigscreen"
-    }
-
     @staticmethod
     def get_class(config=None):
         """Factory method to get a gui engine class based on configuration.
@@ -89,8 +84,6 @@ class OVOSGuiFactory:
         """
         config = get_gui_config(config)
         gui_module = config.get("module") or 'generic'
-        if gui_module in OVOSGuiFactory.MAPPINGS:
-            gui_module = OVOSGuiFactory.MAPPINGS[gui_module]
         if gui_module == 'generic':
             return GUIExtension
         return load_gui_plugin(gui_module)

--- a/ovos_plugin_manager/templates/gui.py
+++ b/ovos_plugin_manager/templates/gui.py
@@ -46,6 +46,8 @@ class GUIExtension:
                 homescreen.start()
 
             self.homescreen_manager = homescreen
+        else:
+            LOG.info("Homescreen support not configured")
 
     def handle_remove_namespace(self, message):
         LOG.info("Got Clear Namespace Event In Skill")

--- a/ovos_plugin_manager/utils/config.py
+++ b/ovos_plugin_manager/utils/config.py
@@ -22,10 +22,6 @@ def get_plugin_config(config: Optional[dict] = None, section: str = None,
     lang = config.get('lang') or Configuration().get('lang')
     config = (config.get('intentBox', {}).get(section) or config.get(section)
               or config) if section else config
-    if section == "gui" and config.get("extension"):
-        LOG.warning(f"`extension` config is deprecated; update config key to "
-                    f"`module`")
-        config.setdefault("module", config.pop('extension'))
     module = module or config.get('module')
     if module:
         module_config = dict(config.get(module) or dict())

--- a/ovos_plugin_manager/utils/config.py
+++ b/ovos_plugin_manager/utils/config.py
@@ -8,7 +8,11 @@ from ovos_plugin_manager.utils import load_plugin, find_plugins, \
 def get_plugin_config(config: Optional[dict] = None, section: str = None,
                       module: Optional[str] = None) -> dict:
     """
-    Get a configuration dict for the specified plugin
+    Get a configuration dict for the specified plugin. Configuration is applied
+    such that:
+    - module-specific configurations take priority
+    - section-specific configuration is appended (new keys only)
+    - global `lang` configuration is appended (if not already set)
     @param config: Base configuration to parse, defaults to `Configuration()`
     @param section: Config section for the plugin (i.e. TTS, STT, language)
     @param module: Module/plugin to get config for, default reads from config
@@ -18,15 +22,22 @@ def get_plugin_config(config: Optional[dict] = None, section: str = None,
     lang = config.get('lang') or Configuration().get('lang')
     config = (config.get('intentBox', {}).get(section) or config.get(section)
               or config) if section else config
+    if section == "gui" and config.get("extension"):
+        LOG.warning(f"`extension` config is deprecated; update config key to "
+                    f"`module`")
+        config.setdefault("module", config.pop('extension'))
     module = module or config.get('module')
     if module:
-        module_config = config.get(module) or dict()
+        module_config = dict(config.get(module) or dict())
         module_config.setdefault('module', module)
-        if section not in ["hotwords", "VAD", "listener"]:
-            module_config.setdefault('lang', lang)
-        LOG.debug(f"Loaded configuration: {module_config}")
-        return module_config
-    if section not in ["hotwords", "VAD", "listener"]:
+        for key, val in config.items():
+            if key == "module":
+                continue
+            elif isinstance(val, dict):
+                continue
+            module_config.setdefault(key, val)
+        config = module_config
+    if section not in ["hotwords", "VAD", "listener", "gui"]:
         config.setdefault('lang', lang)
     LOG.debug(f"Loaded configuration: {config}")
     return config

--- a/ovos_plugin_manager/vad.py
+++ b/ovos_plugin_manager/vad.py
@@ -121,8 +121,10 @@ class OVOSVADFactory:
             raise ValueError(f"VAD Plugin not configured in: {vad_config}")
         try:
             clazz = OVOSVADFactory.get_class(vad_config)
-            vad_config.pop("module")  # module name not expected in config
-            return clazz(vad_config)
+            # module name not expected in config; don't change passed config
+            plugin_config = dict(vad_config)
+            plugin_config.pop("module")
+            return clazz(plugin_config)
         except Exception:
             LOG.exception(f'VAD plugin {plugin} could not be loaded!')
             raise

--- a/ovos_plugin_manager/vad.py
+++ b/ovos_plugin_manager/vad.py
@@ -121,6 +121,7 @@ class OVOSVADFactory:
             raise ValueError(f"VAD Plugin not configured in: {vad_config}")
         try:
             clazz = OVOSVADFactory.get_class(vad_config)
+            vad_config.pop("module")  # module name not expected in config
             return clazz(vad_config)
         except Exception:
             LOG.exception(f'VAD plugin {plugin} could not be loaded!')

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -41,7 +41,7 @@ _MOCK_CONFIG = {
         }
     },
     "gui": {
-        "extension": "ovos-gui-plugin-shell-companion",
+        "module": "ovos-gui-plugin-shell-companion",
         "generic": {"homescreen_supported": True},
         "idle_display_skill": "skill-ovos-homescreen",
         "run_gui_file_server": False

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -39,6 +39,12 @@ _MOCK_CONFIG = {
                 "valid": True
             }
         }
+    },
+    "gui": {
+        "extension": "ovos-gui-plugin-shell-companion",
+        "generic": {"homescreen_supported": True},
+        "idle_display_skill": "skill-ovos-homescreen",
+        "run_gui_file_server": False
     }
 }
 
@@ -555,6 +561,7 @@ class TestConfigUtils(unittest.TestCase):
                                                 "tts-module")
         seg_config = get_plugin_config(_MOCK_CONFIG, "segmentation")
         pos_config = get_plugin_config(_MOCK_CONFIG, "postag")
+        gui_config = get_plugin_config(_MOCK_CONFIG, "gui")
 
         self.assertEqual(tts_config,
                          {"lang": "global",
@@ -581,12 +588,19 @@ class TestConfigUtils(unittest.TestCase):
                           "module": "right-module",
                           "valid": True})
 
+        self.assertEqual(gui_config,
+                         {"module": "ovos-gui-plugin-shell-companion",
+                          "idle_display_skill": "skill-ovos-homescreen",
+                          "run_gui_file_server": False
+                          })
+
         # Test for same behavior with global config
         self.assertEqual(tts_config, get_plugin_config(section="tts"))
         self.assertEqual(stt_config, get_plugin_config(section="stt"))
         self.assertEqual(keyword_config, get_plugin_config(section="keywords"))
         self.assertEqual(pos_config, get_plugin_config(section="postag"))
         self.assertEqual(seg_config, get_plugin_config(section="segmentation"))
+        self.assertEqual(gui_config, get_plugin_config(section="gui"))
 
         self.assertEqual(_MOCK_CONFIG, start_config)
 


### PR DESCRIPTION
This changes configuration handling some to accommodate GUI plugins. Previously, only `lang` was handled from a config section (`stt`, `tts`, `listener`, etc.); this changes handling so any non-dict config within a config section is passed to a plugin.

This enables backwards-compat for GUI plugins