### PR TITLE
Don't swallow plugin load errors

### DIFF
--- a/ovos_plugin_manager/utils/__init__.py
+++ b/ovos_plugin_manager/utils/__init__.py
@@ -108,7 +108,7 @@ def find_plugins(plug_type: PluginTypes = None) -> dict:
                 if entry_point.name not in entrypoints:
                     LOG.debug(f"Loaded plugin entry point {entry_point.name}")
             except Exception as e:
-                LOG.debug(f"Failed to load plugin entry point {entry_point}: "
+                LOG.error(f"Failed to load plugin entry point {entry_point}: "
                           f"{e}")
     return entrypoints
 


### PR DESCRIPTION
This caused me quite a bit of grief while trying to determine why a skill I was working on wasn't loading (turns out it was due to an import problem). Without this patch, all logs were completely silent about why the skill wasn't loading.

I have tested this on my Mark II.

See also this Matrix discussion: https://matrix.to/#/!HhLBuodkbodKsHKufb:matrix.org/$nujXvhEj-bRYLWu6_jg1eYUvUwCYv7rvTFUHXO5o6Lg?via=matrix.org&via=strugee.net