### PR TITLE
fix/playback_thread startup

### DIFF
--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -327,7 +327,9 @@ class TTS:
         TTS.playback.attach_tts(self)
         if not TTS.playback.enclosure:
             TTS.playback.enclosure = EnclosureAPI(self.bus)
-        TTS.playback.start()
+
+        if not TTS.playback._started:
+            TTS.playback.start()
 
     @property
     def enclosure(self):


### PR DESCRIPTION
if using a fallback TTS the thread is started twice and throws an exception
