### PR TITLE
Fix STT and TTS configuration handling

### DIFF
--- a/ovos_plugin_manager/stt.py
+++ b/ovos_plugin_manager/stt.py
@@ -3,7 +3,7 @@ from ovos_plugin_manager.utils import normalize_lang, \
 from ovos_config import Configuration
 from ovos_plugin_manager.utils.config import get_valid_plugin_configs, \
     sort_plugin_configs, get_plugin_config
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_plugin_manager.templates.stt import STT, StreamingSTT, StreamThread
 
 
@@ -154,6 +154,7 @@ class OVOSSTTFactory:
         stt_config = get_stt_config(config)
         plugin = stt_config.get("module", "dummy")
         if plugin in OVOSSTTFactory.MAPPINGS:
+            log_deprecation("Module mappings will be deprecated", "0.1.0")
             plugin = OVOSSTTFactory.MAPPINGS[plugin]
             stt_config = get_stt_config(config, plugin)
         try:

--- a/ovos_plugin_manager/stt.py
+++ b/ovos_plugin_manager/stt.py
@@ -2,7 +2,7 @@ from ovos_plugin_manager.utils import normalize_lang, \
     PluginTypes, PluginConfigTypes
 from ovos_config import Configuration
 from ovos_plugin_manager.utils.config import get_valid_plugin_configs, \
-    sort_plugin_configs
+    sort_plugin_configs, get_plugin_config
 from ovos_utils.log import LOG
 from ovos_plugin_manager.templates.stt import STT, StreamingSTT, StreamThread
 
@@ -152,10 +152,9 @@ class OVOSSTTFactory:
         """
         config = get_stt_config(config)
         plugin = config["module"]
-        plugin_config = config.get(plugin) or {}
         try:
             clazz = OVOSSTTFactory.get_class(config)
-            return clazz(plugin_config)
+            return clazz(get_plugin_config(config, "stt", plugin))
         except Exception:
             LOG.exception('The selected STT plugin could not be loaded!')
             raise

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -6,7 +6,7 @@ from ovos_plugin_manager.utils import PluginTypes, normalize_lang, \
     PluginConfigTypes
 from ovos_plugin_manager.utils.config import get_valid_plugin_configs, \
     sort_plugin_configs, get_plugin_config
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_utils.xdg_utils import xdg_data_home
 from hashlib import md5
 
@@ -196,6 +196,7 @@ class OVOSTTSFactory:
         if tts_module in OVOSTTSFactory.MAPPINGS:
             # The configured module maps to a valid plugin; get configuration
             # again to make sure any module-specific config/overrides are loaded
+            log_deprecation("Module mappings will be deprecated", "0.1.0")
             tts_module = OVOSTTSFactory.MAPPINGS[tts_module]
             tts_config = get_tts_config(config, tts_module)
         try:

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -189,13 +189,12 @@ class OVOSTTSFactory:
         }
         """
         tts_config = get_tts_config(config)
-        tts_lang = tts_config["lang"]
         tts_module = tts_config.get('module', 'dummy')
         try:
             clazz = OVOSTTSFactory.get_class(tts_config)
             if clazz:
                 LOG.info(f'Found plugin {tts_module}')
-                tts = clazz(tts_lang,
+                tts = clazz(None,  # don't pass lang and force read from config
                             get_plugin_config(tts_config, "tts", tts_module))
                 tts.validator.validate()
                 LOG.info(f'Loaded plugin {tts_module}')

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -208,7 +208,7 @@ class OVOSTTSFactory:
                 tts.validator.validate()
                 LOG.info(f'Loaded plugin {tts_module}')
             else:
-                raise FileNotFoundError("unknown plugin")
+                raise RuntimeError(f"unknown plugin: {tts_module}")
         except Exception:
             plugins = find_tts_plugins()
             modules = ",".join(plugins.keys())

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -5,7 +5,7 @@ from ovos_plugin_manager.templates.tts import TTS, TTSContext, TTSValidator, \
 from ovos_plugin_manager.utils import PluginTypes, normalize_lang, \
     PluginConfigTypes
 from ovos_plugin_manager.utils.config import get_valid_plugin_configs, \
-    sort_plugin_configs
+    sort_plugin_configs, get_plugin_config
 from ovos_utils.log import LOG
 from ovos_utils.xdg_utils import xdg_data_home
 from hashlib import md5
@@ -195,7 +195,8 @@ class OVOSTTSFactory:
             clazz = OVOSTTSFactory.get_class(tts_config)
             if clazz:
                 LOG.info(f'Found plugin {tts_module}')
-                tts = clazz(tts_lang, tts_config)
+                tts = clazz(tts_lang,
+                            get_plugin_config(tts_config, "tts", tts_module))
                 tts.validator.validate()
                 LOG.info(f'Loaded plugin {tts_module}')
             else:

--- a/ovos_plugin_manager/utils/config.py
+++ b/ovos_plugin_manager/utils/config.py
@@ -32,6 +32,7 @@ def get_plugin_config(config: Optional[dict] = None, section: str = None,
                 continue
             elif isinstance(val, dict):
                 continue
+            # Use section-scoped config as defaults (i.e. TTS.lang)
             module_config.setdefault(key, val)
         config = module_config
     if section not in ["hotwords", "VAD", "listener", "gui"]:

--- a/test/unittests/test_stt.py
+++ b/test/unittests/test_stt.py
@@ -81,12 +81,12 @@ class TestSTT(unittest.TestCase):
         get_supported_languages.assert_called_once_with(self.PLUGIN_TYPE)
 
     @patch("ovos_plugin_manager.utils.config.get_plugin_config")
-    def test_get_config(self, get_config):
+    def test_get_stt_config(self, get_config):
         from ovos_plugin_manager.stt import get_stt_config
         config = copy(self.TEST_CONFIG)
         get_stt_config(self.TEST_CONFIG)
         get_config.assert_called_once_with(self.TEST_CONFIG,
-                                           self.CONFIG_SECTION)
+                                           self.CONFIG_SECTION, None)
         self.assertEqual(config, self.TEST_CONFIG)
 
 

--- a/test/unittests/test_tts.py
+++ b/test/unittests/test_tts.py
@@ -184,7 +184,7 @@ class TestTTS(unittest.TestCase):
         from ovos_plugin_manager.tts import get_tts_config
         get_tts_config(self.TEST_CONFIG)
         get_config.assert_called_once_with(self.TEST_CONFIG,
-                                           self.CONFIG_SECTION)
+                                           self.CONFIG_SECTION, None)
 
     def test_get_voice_id(self):
         from ovos_plugin_manager.tts import get_voice_id

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -629,6 +629,26 @@ class TestConfigUtils(unittest.TestCase):
         self.assertEqual(seg_config, get_plugin_config(section="segmentation"))
         self.assertEqual(gui_config, get_plugin_config(section="gui"))
 
+        # Test TTS config with plugin `lang` override
+        config = {
+            "lang": "en-us",
+            "tts": {
+                "module": "ovos_tts_plugin_espeakng",
+                "ovos_tts_plugin_espeakng": {
+                  "lang": "de-de",
+                  "voice": "german-mbrola-5",
+                  "speed": "135",
+                  "amplitude": "80",
+                  "pitch": "20"
+                }
+            }
+        }
+        tts_config = get_plugin_config(config, "tts")
+        self.assertEqual(tts_config['lang'], 'de-de')
+        self.assertEqual(tts_config['module'], 'ovos_tts_plugin_espeakng')
+        self.assertEqual(tts_config['voice'], 'german-mbrola-5')
+        self.assertNotIn("ovos_tts_plugin_espeakng", tts_config)
+
         self.assertEqual(_MOCK_CONFIG, start_config)
 
     def test_get_valid_plugin_configs(self):


### PR DESCRIPTION
Fix STT and TTS config handling to pass parsed plugin config to plugin init
Closes #132 

The `get_plugin_config` method is intended to load a complete configuration dict for a plugin where plugin-specific config takes the highest priority, then plugin class config (i.e. 'stt', 'tts'), and then global config (i.e.` Configuration()['lang']`)