### PR TITLE
feat/restore phonetic spellings

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [ 3.8, 3.9, "3.10" ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -227,13 +227,14 @@ class TTS:
         return set()
 
     @abc.abstractmethod
-    def get_tts(self, sentence, wav_file, lang=None):
+    def get_tts(self, sentence, wav_file, lang=None, voice=None):
         """Abstract method that a tts implementation needs to implement.
 
         Args:
             sentence (str): The input sentence to synthesize.
             wav_file (str): The output file path for the synthesized audio.
             lang (str, optional): The requested language (defaults to self.lang).
+            voice (str, optional): The requested voice (defaults to self.voice).
 
         Returns:
             tuple: (wav_file, phoneme)
@@ -275,7 +276,7 @@ class TTS:
         voice = self.config.get("voice") or "default"
         message = dig_for_message()
         if message:
-            sess = SessionManager.get()
+            sess = SessionManager.get(message)
             if sess.tts_preferences["plugin_id"] == self.plugin_id:
                 v = sess.tts_preferences["config"].get("voice")
                 if v:
@@ -293,7 +294,7 @@ class TTS:
     def lang(self):
         message = dig_for_message()
         if message:
-            sess = SessionManager.get()
+            sess = SessionManager.get(message)
             return sess.lang
         return self.config.get("lang") or 'en-us'
 
@@ -561,7 +562,7 @@ class TTS:
 
         # update kwargs from session
         if message:
-            sess = SessionManager.get()
+            sess = SessionManager.get(message)
             if sess.tts_preferences["plugin_id"] == self.plugin_id:
                 for k, v in sess.tts_preferences["config"].items():
                     if k not in kwargs:

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -404,10 +404,9 @@ class TTS:
         if playback is None:
             LOG.warning("PlaybackThread should be inited by ovos-audio, initing via plugin has been deprecated, "
                         "please pass playback=PlaybackThread() to TTS.init")
-            if TTS.playback:
-                playback.shutdown()
-            playback = PlaybackThread(TTS.queue, self.bus)  # compat
-            playback.start()
+            if not TTS.playback:
+                playback = PlaybackThread(TTS.queue, self.bus)  # compat
+                playback.start()
         self._init_playback(playback)
         self.add_metric({"metric_type": "tts.setup"})
 

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -127,6 +127,11 @@ class TTSContext:
             phonemes = pho_file.load()
         return audio_file, phonemes
 
+    @classmethod
+    def curate_caches(cls):
+        for cache in TTSContext._caches.values():
+            cache.curate()
+
 
 class TTS:
     """TTS abstract class to be implemented by all TTS engines.

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -203,8 +203,7 @@ class OVOSTTSFactory:
             clazz = OVOSTTSFactory.get_class(tts_config)
             if clazz:
                 LOG.info(f'Found plugin {tts_module}')
-                tts = clazz(lang=None,  # explicitly read lang from config
-                            config=tts_config)
+                tts = clazz(config=tts_config)
                 tts._plugin_id = tts_module
                 tts.validator.validate()
                 LOG.info(f'Loaded plugin {tts_module}')

--- a/ovos_plugin_manager/tts.py
+++ b/ovos_plugin_manager/tts.py
@@ -205,6 +205,7 @@ class OVOSTTSFactory:
                 LOG.info(f'Found plugin {tts_module}')
                 tts = clazz(lang=None,  # explicitly read lang from config
                             config=tts_config)
+                tts._plugin_id = tts_module
                 tts.validator.validate()
                 LOG.info(f'Loaded plugin {tts_module}')
             else:

--- a/test/unittests/test_tts.py
+++ b/test/unittests/test_tts.py
@@ -248,13 +248,13 @@ class TestTTSFactory(unittest.TestCase):
                            "config": True,
                            "lang": "en-ca"}
         get_class.assert_called_once_with(expected_config)
-        plugin_class.assert_called_once_with(lang=None, config=expected_config)
+        plugin_class.assert_called_once_with(config=expected_config)
         self.assertEqual(plugin, plugin_class())
 
         # Test create with TTS config and no module config
         plugin = OVOSTTSFactory.create(tts_config)
         get_class.assert_called_with(tts_config)
-        plugin_class.assert_called_with(lang=None, config=tts_config)
+        plugin_class.assert_called_with(config=tts_config)
         self.assertEqual(plugin, plugin_class())
 
         # Test create with TTS config with module-specific config
@@ -262,7 +262,7 @@ class TestTTSFactory(unittest.TestCase):
         expected_config = {"module": "test-tts-plugin-test",
                            "config": True, "lang": "es-mx"}
         get_class.assert_called_with(expected_config)
-        plugin_class.assert_called_with(lang=None, config=expected_config)
+        plugin_class.assert_called_with(config=expected_config)
         self.assertEqual(plugin, plugin_class())
 
 

--- a/test/unittests/test_tts.py
+++ b/test/unittests/test_tts.py
@@ -364,32 +364,12 @@ class TestSession(unittest.TestCase):
         self.assertEqual(ctxt.tts_id, f"{tts.plugin_id}/default/en-us")
         self.assertEqual(ctxt.synth_kwargs, {'lang': 'en-us'})
 
-        # test that tts_prefs are used if plugin_id matches
         sess = Session(session_id="123",
-                       lang="klingon",
-                       tts_prefs={"plugin_id": "ovos-tts-plugin-dummy",
-                                  "config": {"voice": "A"}})
+                       lang="klingon")
         m = Message("speak",
                     context={"session": sess.serialize()})
         kwargs = {"message": m}
         ctxt = tts._get_ctxt(kwargs)
         self.assertEqual(ctxt.lang, sess.lang)
-        self.assertEqual(ctxt.voice, sess.tts_preferences["config"]["voice"])
-        self.assertEqual(ctxt.tts_id, f"{tts.plugin_id}/A/klingon")
-        self.assertEqual(ctxt.synth_kwargs, {'lang': 'klingon', 'voice': 'A'})
-
-        # test that tts_prefs are ignored if plugin_id doesnt match
-        sess = Session(session_id="123",
-                       lang="klingon",
-                       tts_prefs={"plugin_id": "ovos-tts-plugin-INVALID",
-                                  "config": {"voice": "A"}})
-        m = Message("speak",
-                    context={"session": sess.serialize()})
-        kwargs = {"message": m}
-        ctxt = tts._get_ctxt(kwargs)
-        self.assertEqual(ctxt.lang, sess.lang)
-        self.assertEqual(ctxt.voice, "default")
-        self.assertNotEqual(ctxt.tts_id, f"ovos-tts-plugin-INVALID/A/klingon")
         self.assertEqual(ctxt.tts_id, f"{tts.plugin_id}/default/klingon")
         self.assertEqual(ctxt.synth_kwargs, {'lang': 'klingon'})
-

--- a/test/unittests/test_tts.py
+++ b/test/unittests/test_tts.py
@@ -267,16 +267,10 @@ class TestTTSFactory(unittest.TestCase):
 
 
 class TestTTSContext(unittest.TestCase):
-    def test_tts_context_init(self):
-        session_mock = MagicMock()
-        tts_context = TTSContext(session=session_mock)
-        self.assertEqual(tts_context.session, session_mock)
-        self.assertEqual(tts_context.lang, session_mock.lang)
 
     @patch("ovos_plugin_manager.templates.tts.TextToSpeechCache", autospec=True)
     def test_tts_context_get_cache(self, cache_mock):
-        session_mock = MagicMock()
-        tts_context = TTSContext(session=session_mock)
+        tts_context = TTSContext("plug", "voice", "lang")
 
         result = tts_context.get_cache()
 
@@ -286,13 +280,13 @@ class TestTTSContext(unittest.TestCase):
 
 class TestTTSCache(unittest.TestCase):
     def setUp(self):
-        self.tts_mock = TTS(lang="en-us", config={"some_config_key": "some_config_value"})
+        self.tts_mock = TTS(config={"some_config_key": "some_config_value"})
         self.tts_mock.stopwatch = MagicMock()
         self.tts_mock.queue = MagicMock()
         self.tts_mock.playback = MagicMock()
 
     @patch("ovos_plugin_manager.templates.tts.hash_sentence", return_value="fake_hash")
-    @patch("ovos_plugin_manager.templates.tts.TTSContext", autospec=True)
+    @patch("ovos_plugin_manager.templates.tts.TTSContext")
     def test_tts_synth(self, tts_context_mock, hash_sentence_mock):
         tts_context_mock.get_cache.return_value = MagicMock()
         tts_context_mock.get_cache.return_value.define_audio_file.return_value.path = "fake_audio_path"
@@ -314,9 +308,28 @@ class TestTTSCache(unittest.TestCase):
         tts_context_mock._caches = {tts_context_mock.tts_id: tts_context_mock.get_cache.return_value}
 
         sentence = "Hello world!"
+        self.tts_mock.enable_cache = True
         result = self.tts_mock.synth(sentence, tts_context_mock)
 
         tts_context_mock.get_cache.assert_called_once_with("wav", self.tts_mock.config)
         tts_context_mock.get_cache.return_value.define_audio_file.assert_called_once_with("fake_hash")
         self.assertEqual(result, (tts_context_mock.get_cache.return_value.define_audio_file.return_value, None))
         self.assertIn("fake_hash", tts_context_mock.get_cache.return_value.cached_sentences)
+
+    @patch("ovos_plugin_manager.templates.tts.hash_sentence", return_value="fake_hash")
+    def test_tts_synth_cache_disabled(self, hash_sentence_mock):
+        tts_context_mock = MagicMock()
+        tts_context_mock.tts_id = "fake_tts_id"
+        tts_context_mock.get_cache.return_value = MagicMock()
+        tts_context_mock.get_cache.return_value.cached_sentences = {}
+        tts_context_mock.get_cache.return_value.define_audio_file.return_value.path = "fake_audio_path"
+        tts_context_mock._caches = {tts_context_mock.tts_id: tts_context_mock.get_cache.return_value}
+
+        sentence = "Hello world!"
+        self.tts_mock.enable_cache = False
+        result = self.tts_mock.synth(sentence, tts_context_mock)
+
+        tts_context_mock.get_cache.assert_called_once_with("wav", self.tts_mock.config)
+        tts_context_mock.get_cache.return_value.define_audio_file.assert_called_once_with("fake_hash")
+        self.assertEqual(result, (tts_context_mock.get_cache.return_value.define_audio_file.return_value, None))
+        self.assertNotIn("fake_hash", tts_context_mock.get_cache.return_value.cached_sentences)


### PR DESCRIPTION
phonetic spellings  used to refer to a [hardcoded english file in mycroft-core specific to mimic1](https://github.com/MycroftAI/mycroft-core/blob/dev/mycroft/res/text/en-us/phonetic_spellings.txt)

now generalized to be per TTS plugin and live in a "locale" folder like everything else

example: https://github.com/OpenVoiceOS/ovos-tts-plugin-mimic/pull/12

per lang/request support for phonetic-spellings :tada: 

TTSContext has also been extended to fully encapsulate the request specific data  (lang/voice/synth_kwargs)
```
class TTSContext:
    """
    A context manager for handling Text-To-Speech (TTS) operations and caching.

    Attributes:
        plugin_id (str): Identifier for the TTS plugin being used.
        lang (str): Language code for the TTS operation.
        voice (str): Identifier for the voice type in use.
        synth_kwargs (dict): Optional dictionary containing additional keyword arguments for the TTS synthesizer.

    Class Attributes:
        _caches (dict): A class-level dictionary acting as a cache store for different TTS contexts.
    """
````

TTS base class was cleaned up in the process
- spit out g2p init into its own method
- make preprocess_sentence public, as its useful for plugins to override
- move cache to TTSContext (because it depends on voice/lang combo)
- move methods around for readability and group them based on functionality, deprecated code at bottom of file (sorry for messing up the git diff!)
- add deprecation warnings
