### PR TITLE
feat/sentence_tokenize_before_TTS

### DIFF
--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -469,7 +469,9 @@ class TTS:
         Returns:
             list: list of sentence parts
         """
-        return quebra_frases.sentence_tokenize(sentence)
+        if self.config.get("sentence_tokenize"): # TODO default to True on next major release
+            return quebra_frases.sentence_tokenize(sentence)
+        return [sentence]
 
     def execute(self, sentence, ident=None, listen=False, **kwargs):
         """Convert sentence to speech, preprocessing out unsupported ssml

--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -25,6 +25,7 @@ import inspect
 import random
 import re
 import subprocess
+import quebra_frases
 from os.path import isfile, join
 from pathlib import Path
 from queue import Queue
@@ -456,7 +457,8 @@ class TTS:
         return utterance.replace("  ", " ")
 
     def _preprocess_sentence(self, sentence):
-        """Default preprocessing is no preprocessing.
+        """Default preprocessing is a sentence_tokenizer, 
+        ie. splits the utterance into sub-sentences using quebra_frases
 
         This method can be overridden to create chunks suitable to the
         TTS engine in question.
@@ -467,7 +469,7 @@ class TTS:
         Returns:
             list: list of sentence parts
         """
-        return [sentence]
+        return quebra_frases.sentence_tokenize(sentence)
 
     def execute(self, sentence, ident=None, listen=False, **kwargs):
         """Convert sentence to speech, preprocessing out unsupported ssml


### PR DESCRIPTION
split large responses into sub-sentences, this improves the TTS synth speed

eg, with this PR the sentence below would have been 3 synths instead of 1, and the first one would start playing while it synthed the next 2

> Jan 03 14:55:37 rpi4b hivemind-voice-sat[10648]: 2024-01-03 14:55:37.257 - HiveMind-voice-sat - ovos_audio.service:execute_tts:348 - INFO - Speak: Quantum computing is a field that focuses on developing computer systems that utilize the principles of quantum mechanics. These systems, known as quantum computers, use quantum bits or qubits to process and store information. Unlike classical computers which use bits that can represent either a 0 or a 1, qubits can exist in multiple states simultaneously, thanks to a property called superposition. This allows quantum computers to perform certain calculations much faster than classical computers, potentially enabling breakthroughs in fields like cryptography, optimization, and molecular simulations. However, quantum computing is still a developing field and many practical challenges need to be overcome before fully functional quantum computers become widely available.


ChatGPT answered quickly but the TTS server took some time to convert it. It took about 20 seconds with ryan-high on Piper, sure it will be faster with a lower voice but still an issue