### PR TITLE
hotfix/clean_shutdown

### DIFF
--- a/ovos_plugin_manager/templates/tts.py
+++ b/ovos_plugin_manager/templates/tts.py
@@ -717,8 +717,6 @@ class TTS:
     def shutdown(self):
         """Shuts down the TTS engine."""
         self.stop()
-        if TTS.playback:
-            TTS.playback.detach_tts(self)
 
     def __del__(self):
         """Destructor for the TTS object."""


### PR DESCRIPTION
missed in #195 refactor

```
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]: 2024-04-29 20:29:55.546 - HiveMind-voice-sat - ovos_config.config:_on_file_change:317 - ERROR - Error in config update callback handler
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]: Traceback (most recent call last):
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_config/config.py", line 315, in _on_file_change
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]:     handler()
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_audio/service.py", line 342, in _maybe_reload_tts
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]:     self.tts.shutdown()
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/templates/tts.py", line 721, in shutdown
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]:     TTS.playback.detach_tts(self)
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]:     ^^^^^^^^^^^^^^^^^^^^^^^
Apr 29 20:29:55 mark1 hivemind-voice-sat[2167]: AttributeError: 'PlaybackThread' object has no attribute 'detach_tts'
```