### PR TITLE
refactor/legacy_audio

### DIFF
--- a/ovos_plugin_manager/templates/audio.py
+++ b/ovos_plugin_manager/templates/audio.py
@@ -229,6 +229,7 @@ class AudioBackend(metaclass=ABCMeta):
     def clear_list(self):
         """Clear playlist."""
         self._tracks = []
+        self._idx = 0
 
     def add_list(self, tracks):
         """Add tracks to backend's playlist.
@@ -243,6 +244,7 @@ class AudioBackend(metaclass=ABCMeta):
             raise ValueError
         if tracks:
             self.load_track(tracks[0])
+            self._idx = 0
         else:
             LOG.error("called add_list without tracks!")
         self._tracks = tracks

--- a/ovos_plugin_manager/templates/audio.py
+++ b/ovos_plugin_manager/templates/audio.py
@@ -4,19 +4,54 @@ These classes can be used to create an Audioservice plugin extending
 OpenVoiceOS's media playback options.
 """
 from abc import ABCMeta, abstractmethod
+from typing import List
 
 from ovos_bus_client import Message
 from ovos_bus_client.message import dig_for_message
 from ovos_utils import classproperty
-from ovos_utils.log import log_deprecation, LOG
 from ovos_utils.fakebus import FakeBus
+from ovos_utils.log import log_deprecation, LOG
 from ovos_utils.process_utils import RuntimeRequirements
 
 try:
-    from ovos_utils.ocp import PlaybackType, TrackState
+    from ovos_utils.ocp import PlaybackType, TrackState, PlayerState, MediaState
 except ImportError:
     LOG.warning("Please update to ovos-utils~=0.1.")
     from enum import IntEnum
+
+
+    class MediaState(IntEnum):
+        # https://doc.qt.io/qt-5/qmediaplayer.html#MediaStatus-enum
+        # The status of the media cannot be determined.
+        UNKNOWN = 0
+        # There is no current media. PlayerState == STOPPED
+        NO_MEDIA = 1
+        # The current media is being loaded. The player may be in any state.
+        LOADING_MEDIA = 2
+        # The current media has been loaded. PlayerState== STOPPED
+        LOADED_MEDIA = 3
+        # Playback of the current media has stalled due to
+        # insufficient buffering or some other temporary interruption.
+        # PlayerState != STOPPED
+        STALLED_MEDIA = 4
+        # The player is buffering data but has enough data buffered
+        # for playback to continue for the immediate future.
+        # PlayerState != STOPPED
+        BUFFERING_MEDIA = 5
+        # The player has fully buffered the current media. PlayerState != STOPPED
+        BUFFERED_MEDIA = 6
+        # Playback has reached the end of the current media. PlayerState == STOPPED
+        END_OF_MEDIA = 7
+        # The current media cannot be played. PlayerState == STOPPED
+        INVALID_MEDIA = 8
+
+
+    class PlayerState(IntEnum):
+        # https://doc.qt.io/qt-5/qmediaplayer.html#State-enum
+        STOPPED = 0
+        PLAYING = 1
+        PAUSED = 2
+
 
     class PlaybackType(IntEnum):
         SKILL = 0  # skills handle playback whatever way they see fit,
@@ -45,10 +80,6 @@ except ImportError:
         QUEUED_WEBVIEW = 34  # Waiting playback in browser service
 
 
-log_deprecation("ovos_plugin_manager.templates.audio has been deprecated on ovos-audio, "
-                "move to ovos_plugin_manager.templates.media", "0.1.0")
-
-
 class AudioBackend(metaclass=ABCMeta):
     """Base class for all audio backend implementations.
 
@@ -58,6 +89,8 @@ class AudioBackend(metaclass=ABCMeta):
     """
 
     def __init__(self, config=None, bus=None):
+        self._now_playing = None  # single uri
+        self._tracks = []  # list of dicts for OCP entries
         self._track_start_callback = None
         self.supports_mime_hints = False
         self.config = config or {}
@@ -99,52 +132,17 @@ class AudioBackend(metaclass=ABCMeta):
                                    no_network_fallback=True)
 
     @property
-    def playback_time(self):
-        return 0
+    @abstractmethod
+    def playback_time(self) -> int:
+        """ in milliseconds """
 
-    def supported_uris(self):
+    @abstractmethod
+    def supported_uris(self) -> List[str]:
         """List of supported uri types.
 
         Returns:
             list: Supported uri's
         """
-
-    def clear_list(self):
-        """Clear playlist."""
-        msg = Message('ovos.common_play.playlist.clear')
-        self.bus.emit(msg)
-
-    @abstractmethod
-    def add_list(self, tracks):
-        """Add tracks to backend's playlist.
-
-        Arguments:
-            tracks (list): list of tracks.
-        """
-        tracks = tracks or []
-        if isinstance(tracks, (str, tuple)):
-            tracks = [tracks]
-        elif not isinstance(tracks, list):
-            raise ValueError
-        tracks = [self._uri2meta(t) for t in tracks]
-        msg = Message('ovos.common_play.playlist.queue',
-                      {'tracks': tracks})
-        self.bus.emit(msg)
-
-    @staticmethod
-    def _uri2meta(uri):
-        if isinstance(uri, list):
-            uri = uri[0]
-        try:
-            from ovos_ocp_files_plugin.plugin import OCPFilesMetadataExtractor
-            return OCPFilesMetadataExtractor.extract_metadata(uri)
-        except:
-            meta = {"uri": uri,
-                    "skill_id": "mycroft.audio_interface",
-                    "playback": PlaybackType.AUDIO,  # TODO mime type check
-                    "status": TrackState.QUEUED_AUDIO,
-                    }
-        return meta
 
     @abstractmethod
     def play(self, repeat=False):
@@ -157,6 +155,58 @@ class AudioBackend(metaclass=ABCMeta):
             repeat (bool): Repeat playlist, defaults to False
         """
 
+    @abstractmethod
+    def lower_volume(self):
+        """Lower volume.
+
+        This method is used to implement audio ducking. It will be called when
+        OpenVoiceOS is listening or speaking to make sure the media playing isn't
+        interfering.
+        """
+
+    @abstractmethod
+    def restore_volume(self):
+        """Restore normal volume.
+
+        Called when to restore the playback volume to previous level after
+        OpenVoiceOS has lowered it using lower_volume().
+        """
+
+    @abstractmethod
+    def get_track_length(self) -> int:
+        """
+        getting the duration of the audio in miliseconds
+        """
+
+    @abstractmethod
+    def get_track_position(self) -> int:
+        """
+        get current position in miliseconds
+        """
+
+    @abstractmethod
+    def set_track_position(self, milliseconds):
+        """Go to X position.
+        Arguments:
+           milliseconds (int): position to go to in milliseconds
+        """
+
+    @abstractmethod
+    def pause(self):
+        """Pause playback.
+
+        Stops playback but may be resumed at the exact position the pause
+        occured.
+        """
+
+    @abstractmethod
+    def resume(self):
+        """Resume paused playback.
+
+        Resumes playback after being paused.
+        """
+
+    @abstractmethod
     def stop(self):
         """Stop playback.
 
@@ -166,82 +216,14 @@ class AudioBackend(metaclass=ABCMeta):
             bool: True if playback was stopped, otherwise False
         """
 
-    def set_track_start_callback(self, callback_func):
-        """Register callback on track start.
-
-        This method should be called as each track in a playlist is started.
+    #####################
+    # internals and default implementations
+    def track_info(self) -> dict:
+        """Request information of current playing track.
+        Returns:
+            Dict with track info.
         """
-        self._track_start_callback = callback_func
-
-    def pause(self):
-        """Pause playback.
-
-        Stops playback but may be resumed at the exact position the pause
-        occured.
-        """
-        msg = Message('ovos.common_play.pause')
-        self.bus.emit(msg)
-
-    def resume(self):
-        """Resume paused playback.
-
-        Resumes playback after being paused.
-        """
-        msg = Message('ovos.common_play.resume')
-
-    def next(self):
-        """Skip to next track in playlist."""
-        self.bus.emit(Message("ovos.common_play.next"))
-
-    def previous(self):
-        """Skip to previous track in playlist."""
-        self.bus.emit(Message("ovos.common_play.previous"))
-
-    def lower_volume(self):
-        """Lower volume.
-
-        This method is used to implement audio ducking. It will be called when
-        OpenVoiceOS is listening or speaking to make sure the media playing isn't
-        interfering.
-        """
-
-    def restore_volume(self):
-        """Restore normal volume.
-
-        Called when to restore the playback volume to previous level after
-        OpenVoiceOS has lowered it using lower_volume().
-        """
-
-    def get_track_length(self):
-        """
-        getting the duration of the audio in miliseconds
-        """
-        length = 0
-        msg = self._format_msg('ovos.common_play.get_track_length')
-        info = self.bus.wait_for_response(msg, timeout=1)
-        if info:
-            length = info.data.get("length", 0)
-        return length
-
-    def get_track_position(self):
-        """
-        get current position in miliseconds
-        """
-        pos = 0
-        msg = self._format_msg('ovos.common_play.get_track_position')
-        info = self.bus.wait_for_response(msg, timeout=1)
-        if info:
-            pos = info.data.get("position", 0)
-        return pos
-
-    def set_track_position(self, milliseconds):
-        """Go to X position.
-        Arguments:
-           milliseconds (int): position to go to in milliseconds
-        """
-        msg = self._format_msg('ovos.common_play.set_track_position',
-                               {"position": milliseconds})
-        self.bus.emit(msg)
+        return self._uri2meta(self._now_playing)
 
     def seek_forward(self, seconds=1):
         """Skip X seconds.
@@ -249,9 +231,9 @@ class AudioBackend(metaclass=ABCMeta):
         Arguments:
             seconds (int): number of seconds to seek, if negative rewind
         """
-        msg = self._format_msg('ovos.common_play.seek',
-                               {"seconds": seconds})
-        self.bus.emit(msg)
+        miliseconds = seconds * 1000
+        new_pos = self.get_track_position() + miliseconds
+        self.set_track_position(new_pos)
 
     def seek_backward(self, seconds=1):
         """Rewind X seconds.
@@ -259,18 +241,16 @@ class AudioBackend(metaclass=ABCMeta):
         Arguments:
             seconds (int): number of seconds to seek, if negative jump forward.
         """
-        msg = self._format_msg('ovos.common_play.seek',
-                               {"seconds": seconds * -1})
-        self.bus.emit(msg)
+        miliseconds = seconds * 1000
+        new_pos = self.get_track_position() - miliseconds
+        self.set_track_position(new_pos)
 
-    def track_info(self):
-        """Request information of current playing track.
-        Returns:
-            Dict with track info.
+    def set_track_start_callback(self, callback_func):
+        """Register callback on track start.
+
+        This method should be called as each track in a playlist is started.
         """
-        msg = self._format_msg('ovos.common_play.track_info')
-        response = self.bus.wait_for_response(msg)
-        return response.data if response else {}
+        self._track_start_callback = callback_func
 
     def shutdown(self):
         """Perform clean shutdown.
@@ -293,6 +273,112 @@ class AudioBackend(metaclass=ABCMeta):
         if sauce == "skills":
             msg.context["source"] = "audio_service"
         return msg
+
+    ####################################
+    # OCP wrappers
+    #   default to playlist support via OCP
+    def clear_list(self):
+        """Clear playlist."""
+        self._tracks = []
+        self.bus.emit(Message("ovos.common_play.playlist.clear"))
+
+    def add_list(self, tracks):
+        """Add tracks to backend's playlist.
+
+        Arguments:
+            tracks (list): list of tracks.
+        """
+        tracks = tracks or []
+        if isinstance(tracks, (str, tuple)):
+            tracks = [tracks]
+        elif not isinstance(tracks, list):
+            raise ValueError
+        self.load_track(tracks[0])
+        self._tracks = [self._uri2meta(t) for t in tracks]
+        self.bus.emit(Message('ovos.common_play.playlist.queue',
+                              {'tracks': self._tracks}))
+        self.track_info()  # will trigger update in track data
+
+    def next(self):
+        """Skip to next track in playlist."""
+        self.bus.emit(Message("ovos.common_play.next"))
+
+    def previous(self):
+        """Skip to previous track in playlist."""
+        self.bus.emit(Message("ovos.common_play.previous"))
+
+    ############################
+    # OCP extensions - new methods to improve compat with OCP
+    @staticmethod
+    def _uri2meta(uri):
+        if isinstance(uri, list):
+            uri = uri[0]
+        try:
+            from ovos_ocp_files_plugin.plugin import OCPFilesMetadataExtractor
+            return OCPFilesMetadataExtractor.extract_metadata(uri)
+        except:
+            meta = {"uri": uri,
+                    "skill_id": "mycroft.audio_interface",
+                    "playback": PlaybackType.AUDIO,  # TODO mime type check
+                    "status": TrackState.QUEUED_AUDIO,
+                    }
+        return meta
+
+    def load_track(self, uri):
+        """ This method is only used by ovos-core
+        In ovos audio backends are single-track, playlists are handled by OCP
+        """
+        self._now_playing = uri
+        LOG.debug(f"queuing for {self.__class__.__name__} playback: {uri}")
+        self.bus.emit(Message("ovos.common_play.media.state",
+                              {"state": MediaState.LOADED_MEDIA}))
+        self.bus.emit(Message("ovos.common_play.track.state", {
+            "state": TrackState.QUEUED_AUDIOSERVICE
+        }))
+
+    def ocp_sync_playback(self, playback_time):
+        self.bus.emit(Message("ovos.common_play.playback_time",
+                              {"position": playback_time,
+                               "length": self.get_track_length()}))
+
+    def ocp_start(self):
+        """Emit OCP status events for play"""
+        self.bus.emit(Message("ovos.common_play.player.state",
+                              {"state": PlayerState.PLAYING}))
+        self.bus.emit(Message("ovos.common_play.media.state",
+                              {"state": MediaState.LOADED_MEDIA}))
+        self.bus.emit(Message("ovos.common_play.track.state",
+                              {"state": TrackState.PLAYING_AUDIOSERVICE}))
+
+    def ocp_error(self):
+        """Emit OCP status events for playback error"""
+        if self._now_playing:
+            self.bus.emit(Message("ovos.common_play.media.state",
+                                  {"state": MediaState.INVALID_MEDIA}))
+            self._now_playing = None
+
+    def ocp_stop(self):
+        """Emit OCP status events for stop"""
+        if self._now_playing:
+            self._now_playing = None
+            self.bus.emit(Message("ovos.common_play.player.state",
+                                  {"state": PlayerState.STOPPED}))
+            self.bus.emit(Message("ovos.common_play.media.state",
+                                  {"state": MediaState.END_OF_MEDIA}))
+
+    def ocp_pause(self):
+        """Emit OCP status events for pause"""
+        if self._now_playing:
+            self.bus.emit(Message("ovos.common_play.player.state",
+                                  {"state": PlayerState.PAUSED}))
+
+    def ocp_resume(self):
+        """Emit OCP status events for resume"""
+        if self._now_playing:
+            self.bus.emit(Message("ovos.common_play.player.state",
+                                  {"state": PlayerState.PLAYING}))
+            self.bus.emit(Message("ovos.common_play.track.state",
+                                  {"state": TrackState.PLAYING_AUDIOSERVICE}))
 
 
 class RemoteAudioBackend(AudioBackend):


### PR DESCRIPTION
- helps keeping the legacy plugins alive independently of OCP
- use abstractmethods to force implementation of key pieces in plugins
- drop plugin dependencies on common_play base class -> port utils from https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/blob/dev/ovos_plugin_common_play/ocp/base.py#L66
- default playlist handling implementation, plugins don't need to worry about this and usage in ovos-audio is deprecated
- move methods around for readability (sorry for messing the git diff!)

companion PRs: https://github.com/OpenVoiceOS/ovos-audio-plugin-simple/pull/10 https://github.com/OpenVoiceOS/ovos-plugin-vlc/pull/7 https://github.com/OpenVoiceOS/ovos-audio/pull/64