### PR TITLE
fix/playback_time_not_abstract

### DIFF
--- a/ovos_plugin_manager/templates/audio.py
+++ b/ovos_plugin_manager/templates/audio.py
@@ -133,9 +133,9 @@ class AudioBackend(metaclass=ABCMeta):
                                    no_network_fallback=True)
 
     @property
-    @abstractmethod
     def playback_time(self) -> int:
         """ in milliseconds """
+        return 0
 
     @abstractmethod
     def supported_uris(self) -> List[str]:


### PR DESCRIPTION
the playback_time property does not need to be an abstract method, and it causes OCP to fail to load