### PR TITLE
fix/py3.12

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,3 +8,6 @@ langcodes~=3.3.0
 
 # see https://github.com/pypa/setuptools/issues/1471
 importlib_metadata
+
+# needed explicitly since python 3.12
+setuptools


### PR DESCRIPTION
setuptools needs to be explicitly installed now, or OPM fails to scan plugins

```
    from ovos_plugin_manager.templates.solvers import QuestionSolver
  File "/home/miro/PycharmProjects/ovos-MoS/.venv/lib/python3.12/site-packages/ovos_plugin_manager/__init__.py", line 1, in <module>
    from ovos_plugin_manager.utils import PluginTypes
  File "/home/miro/PycharmProjects/ovos-MoS/.venv/lib/python3.12/site-packages/ovos_plugin_manager/utils/__init__.py", line 19, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'

```