### PR TITLE
refactor/improve_readwritestream

### DIFF
--- a/ovos_plugin_manager/templates/transformers.py
+++ b/ovos_plugin_manager/templates/transformers.py
@@ -95,9 +95,11 @@ class AudioTransformer:
 
         # buffers with audio chunks to be used in predictions
         # always cleared before STT stage
-        self.noise_feed = ReadWriteStream()
-        self.hotword_feed = ReadWriteStream()
-        self.speech_feed = ReadWriteStream()
+        # 16000 samples/second * 2 bytes/sample * 3 seconds = 96000 bytes.
+        self.noise_feed = ReadWriteStream(max_size=96000)  # 3 second buffer
+        self.hotword_feed = ReadWriteStream(max_size=96000)  # 3 seconds buffer
+        # 16000 samples/second * 2 bytes/sample * 10 seconds = 320000 bytes.
+        self.speech_feed = ReadWriteStream(max_size=320000)  # 10 seconds buffer
 
     def _read_mycroft_conf(self):
         config_core = dict(Configuration())

--- a/test/unittests/test_audio_transformers.py
+++ b/test/unittests/test_audio_transformers.py
@@ -1,12 +1,60 @@
 import unittest
+import time
 from unittest.mock import patch
 
-from ovos_plugin_manager.utils import PluginTypes, PluginConfigTypes
+from ovos_plugin_manager.utils import PluginTypes, PluginConfigTypes, ReadWriteStream
+
+
+class TestReadWriteStream(unittest.TestCase):
+    def test_write_and_read(self):
+        # Initialize the stream
+        stream = ReadWriteStream()
+
+        # Write some data to the stream
+        stream.write(b'1234567890abcdefghijklmnopqrstuvwxyz')
+
+        # Read some data from the stream
+        self.assertEqual(stream.read(10), b'1234567890')
+
+        # Read more data with a timeout
+        self.assertEqual(stream.read(5, timeout=1), b'abcde')
+
+    def test_clear_buffer(self):
+        # Initialize the stream
+        stream = ReadWriteStream()
+
+        # Write some data to the stream
+        stream.write(b'1234567890abcdefghijklmnopqrstuvwxyz')
+
+        # Clear the buffer
+        stream.clear()
+        self.assertEqual(len(stream), 0)
+
+    def test_write_with_max_size(self):
+        # Initialize the stream with a max size of 20 bytes
+        stream = ReadWriteStream(max_size=20)
+
+        # Write some data to the stream
+        stream.write(b'1234567890abcdefghijklmnopqrstuvwxyz')
+
+        # The buffer should have been trimmed to the last 20 bytes
+        self.assertEqual(stream.read(20), b'ghijklmnopqrstuvwxyz')
+
+    def test_clear_buffer_with_max_size(self):
+        # Initialize the stream with a max size of 20 bytes
+        stream = ReadWriteStream(max_size=20)
+
+        # Write some data to the stream
+        stream.write(b'1234567890abcdefghijklmnopqrstuvwxyz')
+
+        # Clear the buffer
+        stream.clear()
+        self.assertEqual(len(stream), 0)
 
 
 class TestAudioTransformersTemplate(unittest.TestCase):
     def test_audio_transformer(self):
-        from ovos_plugin_manager.templates.transformers import AudioTransformer
+        pass
         # TODO
 
 


### PR DESCRIPTION
improve the ReadWriteStream class used by audio transformers

make it threadsafe and more performant by using a deque

add a max size to ensure it doesnt grow forever

maybe fixes undiagnosed issue https://github.com/OpenVoiceOS/ovos-dinkum-listener/issues/98