### PR TITLE
refactor/solver_decorators

### DIFF
--- a/ovos_plugin_manager/templates/solvers.py
+++ b/ovos_plugin_manager/templates/solvers.py
@@ -192,9 +192,33 @@ class AbstractSolver:
         self.default_lang = internal_lang or self.config.get("lang", "en")
         if self.default_lang not in self.supported_langs:
             self.supported_langs.insert(0, self.default_lang)
-        self.translator = translator or OVOSLangTranslationFactory.create()
-        self.detector = detector or OVOSLangDetectionFactory.create()
+        self._translator = translator or OVOSLangTranslationFactory.create() if self.enable_tx else None
+        self._detector = detector or OVOSLangDetectionFactory.create() if self.enable_tx else None
         LOG.debug(f"{self.__class__.__name__} default language: {self.default_lang}")
+
+    @property
+    def detector(self):
+        """ language detector, lazy init on first access"""
+        if not self._detector:
+            # if it's being used, there is no recovery, do not try: except:
+            self._detector = OVOSLangDetectionFactory.create()
+        return self._detector
+
+    @detector.setter
+    def detector(self, val):
+        self._detector = val
+
+    @property
+    def translator(self):
+        """ language translator, lazy init on first access"""
+        if not self._translator:
+            # if it's being used, there is no recovery, do not try: except:
+            self._translator = OVOSLangTranslationFactory.create()
+        return self._translator
+
+    @translator.setter
+    def translator(self, val):
+        self._translator = val
 
     @staticmethod
     def sentence_split(text: str, max_sentences: int = 25) -> List[str]:

--- a/ovos_plugin_manager/templates/solvers.py
+++ b/ovos_plugin_manager/templates/solvers.py
@@ -18,7 +18,7 @@ from ovos_plugin_manager.templates.language import LanguageTranslator, LanguageD
 
 def _deprecate_context2lang():
     """Decorator to deprecate the 'context' kwarg and replace it with 'lang'.
-    NOTE: can only be used in methods that accept both "lang" and "context" as arguments"""
+    NOTE: can only be used in methods that accept "lang" as argument"""
 
     def func_decorator(func):
 
@@ -49,7 +49,30 @@ def _deprecate_context2lang():
     return func_decorator
 
 
-def auto_translate(translate_keys: List[str]):
+def _do_tx(solver, data, source_lang, target_lang):
+    if isinstance(data, str):
+        return solver.translate(data,
+                                source_lang=source_lang, target_lang=target_lang)
+    elif isinstance(data, list):
+        for idx, e in enumerate(data):
+            data[idx] = _do_tx(solver, e, source_lang=source_lang, target_lang=target_lang)
+    elif isinstance(data, dict):
+        for k, v in data.items():
+            data[k] = _do_tx(solver, v, source_lang=source_lang, target_lang=target_lang)
+    elif isinstance(data, tuple) and len(data) == 2:
+        if isinstance(data[0], str):
+            a = _do_tx(solver, data[0], source_lang=source_lang, target_lang=target_lang)
+        else:
+            a = data[0]
+        if isinstance(data[1], str):
+            b = _do_tx(solver, data[1], source_lang=source_lang, target_lang=target_lang)
+        else:
+            b = data[1]
+        return (a, b)
+    return data
+
+
+def auto_translate(translate_keys: List[str], translate_str_args=True):
     """ Decorator to ensure all kwargs in 'translate_keys' are translated to self.default_lang.
     data returned by the decorated function will be translated back to original language
      NOTE: not meant to be used outside solver plugins"""
@@ -63,55 +86,74 @@ def auto_translate(translate_keys: List[str]):
             if not solver.enable_tx:
                 return func(*args, **kwargs)
 
-            # detect language if needed
             lang = kwargs.get("lang")
-            if lang is None:
-                for k in translate_keys:
-                    v = kwargs.get(k)
-                    if isinstance(v, str):
-                        lang = solver.detect_language(v)
-                        break
-
             # check if translation can be skipped
             if any([lang is None,
                     lang == solver.default_lang,
                     lang in solver.supported_langs]):
+                LOG.debug(f"skipping translation, 'lang': {lang} is supported by {func}")
                 return func(*args, **kwargs)
+
+            # translate string arguments
+            if translate_str_args:
+                args = list(args)
+                for idx, arg in enumerate(args):
+                    if isinstance(arg, str):
+                        LOG.debug(
+                            f"translating string argument with index: '{idx}' from {lang} to {solver.default_lang} for func: {func}")
+                        args[idx] = _do_tx(solver, arg,
+                                           source_lang=lang,
+                                           target_lang=solver.default_lang)
 
             # translate input keys
             for k in translate_keys:
                 v = kwargs.get(k)
-                if isinstance(v, str):
-                    if v.startswith("http"):
-                        continue
-                    kwargs[k] = solver.translate(v,
-                                                 source_lang=lang,
-                                                 target_lang=solver.default_lang)
-                elif isinstance(v, list):
-                    kwargs[k] = solver.translate_list(v,
-                                                      source_lang=lang,
-                                                      target_lang=solver.default_lang)
-                elif isinstance(v, dict):
-                    kwargs[k] = solver.translate_dict(v,
-                                                      source_lang=lang,
-                                                      target_lang=solver.default_lang)
+                if not v:
+                    continue
+                kwargs[k] = _do_tx(solver, v,
+                                   source_lang=lang,
+                                   target_lang=solver.default_lang)
 
-            output = func(*args, **kwargs)
+            out = func(*args, **kwargs)
 
             # reverse translate
-            if isinstance(output, str):
-                return solver.translate(output,
-                                        source_lang=solver.default_lang,
-                                        target_lang=lang)
-            elif isinstance(output, list):
-                return solver.translate_list(output,
-                                             source_lang=solver.default_lang,
-                                             target_lang=lang)
-            elif isinstance(output, dict):
-                return solver.translate_dict(output,
-                                             source_lang=solver.default_lang,
-                                             target_lang=lang)
-            return output
+            return _do_tx(solver, out,
+                          source_lang=solver.default_lang,
+                          target_lang=lang)
+
+        return func_wrapper
+
+    return func_decorator
+
+
+def auto_detect_lang(text_keys: List[str]):
+    """ Decorator to auto detect language if needed
+    NOTE: requires "lang" argument, not meant to be used outside solver plugins"""
+
+    def func_decorator(func):
+
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            solver: AbstractSolver = args[0]
+
+            # detect language if needed
+            lang = kwargs.get("lang")
+            if lang is None:
+                LOG.debug(f"'lang' missing in kwargs for func: {func}")
+                for k in text_keys:
+                    v = kwargs.get(k)
+                    if isinstance(v, str):
+                        lang = solver.detect_language(v)
+                        LOG.debug(f"detected 'lang': {lang} in key: '{k}' for func: {func}")
+                        break
+                else:
+                    for idx, v in enumerate(args):
+                        if isinstance(v, str) and len(v.split(" ")) > 1:
+                            lang = solver.detect_language(v)
+                            LOG.debug(f"detected 'lang': {lang} in argument '{idx}' for func: {func}")
+
+            kwargs["lang"] = lang
+            return func(*args, **kwargs)
 
         return func_wrapper
 
@@ -140,13 +182,14 @@ class AbstractSolver:
                  priority=50,
                  enable_tx=False,
                  enable_cache=False,
+                 internal_lang: Optional[str] = None,
                  *args, **kwargs):
         self.priority = priority
         self.enable_tx = enable_tx
         self.enable_cache = enable_cache
         self.config = config or {}
         self.supported_langs = self.config.get("supported_langs") or []
-        self.default_lang = self.config.get("lang", "en")
+        self.default_lang = internal_lang or self.config.get("lang", "en")
         if self.default_lang not in self.supported_langs:
             self.supported_langs.insert(0, self.default_lang)
         self.translator = translator or OVOSLangTranslationFactory.create()
@@ -246,6 +289,7 @@ class QuestionSolver(AbstractSolver):
                  priority: int = 50,
                  enable_tx: bool = False,
                  enable_cache: bool = False,
+                 internal_lang: Optional[str] = None,
                  *args, **kwargs):
         """
         Initialize the QuestionSolver.
@@ -257,8 +301,8 @@ class QuestionSolver(AbstractSolver):
         :param enable_tx: Flag to enable translation.
         :param enable_cache: Flag to enable caching.
         """
-        super().__init__(config, translator, detector,
-                         priority, enable_tx, enable_cache,
+        super().__init__(config, translator, detector, priority,
+                         enable_tx, enable_cache, internal_lang,
                          *args, **kwargs)
         name = kwargs.get("name") or self.__class__.__name__
         if self.enable_cache:
@@ -335,6 +379,7 @@ class QuestionSolver(AbstractSolver):
 
     # user facing methods
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["query"])
     @auto_translate(translate_keys=["query"])
     def search(self, query: str, lang: Optional[str] = None) -> dict:
         """
@@ -366,6 +411,7 @@ class QuestionSolver(AbstractSolver):
         return data
 
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["query"])
     @auto_translate(translate_keys=["query"])
     def visual_answer(self, query: str, lang: Optional[str] = None) -> str:
         """
@@ -383,6 +429,7 @@ class QuestionSolver(AbstractSolver):
         return _call_with_sanitized_kwargs(self.get_image, query, lang=lang)
 
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["query"])
     @auto_translate(translate_keys=["query"])
     def spoken_answer(self, query: str, lang: Optional[str] = None) -> str:
         """
@@ -411,6 +458,7 @@ class QuestionSolver(AbstractSolver):
         return summary
 
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["query"])
     @auto_translate(translate_keys=["query"])
     def long_answer(self, query: str, lang: Optional[str] = None) -> List[dict]:
         """
@@ -436,6 +484,79 @@ class QuestionSolver(AbstractSolver):
         return steps
 
 
+class CorpusSolver(QuestionSolver):
+    """Retrieval based question solver"""
+    def __init__(self, config=None,
+                 translator: Optional[LanguageTranslator] = None,
+                 detector: Optional[LanguageDetector] = None,
+                 priority: int = 50,
+                 enable_tx: bool = False,
+                 enable_cache: bool = False,
+                 *args, **kwargs):
+        super().__init__(config, translator, detector,
+                         priority, enable_tx, enable_cache,
+                         *args, **kwargs)
+        LOG.debug(f"corpus presumed to be in language: {self.default_lang}")
+
+    @abc.abstractmethod
+    def load_corpus(self, corpus: List[str]):
+        """index the provided list of sentences"""
+
+    @abc.abstractmethod
+    def query(self, query: str, lang: Optional[str], k: int = 3) -> Iterable[Tuple[str, float]]:
+        """return top_k matches from indexed corpus"""
+
+    @auto_detect_lang(text_keys=["query"])
+    @auto_translate(translate_keys=["query"])
+    def retrieve_from_corpus(self, query: str, k: int = 3, lang: Optional[str] = None) -> List[Tuple[float, str]]:
+        """return top_k matches from indexed corpus"""
+        res = []
+        for doc, score in self.query(query, lang, k=k):
+            LOG.debug(f"Rank {len(res) + 1} (score: {score}): {doc}")
+            if self.config.get("min_conf"):
+                if score >= self.config["min_conf"]:
+                    res.append((score, doc))
+            else:
+                res.append((score, doc))
+        return res
+
+    @auto_detect_lang(text_keys=["query"])
+    @auto_translate(translate_keys=["query"])
+    def get_spoken_answer(self, query: str, lang: Optional[str] = None) -> str:
+        # Query the corpus
+        answers = [a[1] for a in self.retrieve_from_corpus(query, lang=lang,
+                                                           k=self.config.get("n_answer", 1))]
+        if answers:
+            return ". ".join(answers[:self.config.get("n_answer", 1)])
+
+
+class QACorpusSolver(CorpusSolver):
+    def __init__(self, config=None,
+                 translator: Optional[LanguageTranslator] = None,
+                 detector: Optional[LanguageDetector] = None,
+                 priority: int = 50,
+                 enable_tx: bool = False,
+                 enable_cache: bool = False,
+                 *args, **kwargs):
+        self.answers = {}
+        super().__init__(config, translator, detector,
+                         priority, enable_tx, enable_cache,
+                         *args, **kwargs)
+
+    def load_corpus(self, corpus: Dict):
+        self.answers = corpus
+        super().load_corpus(list(self.answers.keys()))
+
+    @auto_detect_lang(text_keys=["query"])
+    @auto_translate(translate_keys=["query"])
+    def retrieve_from_corpus(self, query: str, k: int = 1, lang: Optional[str] = None) -> List[Tuple[float, str]]:
+        res = []
+        for doc, score in super().retrieve_from_corpus(query, k, lang):
+            LOG.debug(f"Answer {len(res) + 1} (score: {score}): {self.answers[doc]}")
+            res.append((score, self.answers[doc]))
+        return res
+
+
 class TldrSolver(AbstractSolver):
     """
     Solver for performing NLP summarization tasks,
@@ -457,6 +578,7 @@ class TldrSolver(AbstractSolver):
     # user facing methods
 
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["document"])
     @auto_translate(translate_keys=["document"])
     def tldr(self, document: str, lang: Optional[str] = None) -> str:
         """
@@ -496,6 +618,7 @@ class EvidenceSolver(AbstractSolver):
 
     # user facing methods
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["evidence", "question"])
     @auto_translate(translate_keys=["evidence", "question"])
     def extract_answer(self, evidence: str, question: str,
                        lang: Optional[str] = None) -> str:
@@ -522,25 +645,23 @@ class MultipleChoiceSolver(AbstractSolver):
     handling automatic translation as needed.
     """
 
-    # plugin methods to override
-
-    # TODO  - make abstract in the future,
-    #  just giving some time buffer to update existing
-    #  plugins in the wild missing this method
-    # @abc.abstractmethod
+    @abc.abstractmethod
     def rerank(self, query: str, options: List[str],
-               lang: Optional[str] = None) -> List[Tuple[float, str]]:
+               lang: Optional[str] = None,
+               return_index: bool = False) -> List[Tuple[float, Union[str, int]]]:
         """
         Rank the provided options based on the query.
 
         :param query: The query text, assured to be in the default language.
         :param options: A list of answer options, each assured to be in the default language.
         :param lang: Optional language code.
+        :param return_index: If True, return the index of the best option; otherwise, return the best option text.
         :return: A list of tuples where each tuple contains a score and the corresponding option text, sorted by score.
         """
         raise NotImplementedError
 
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["query", "options"])
     @auto_translate(translate_keys=["query", "options"])
     def select_answer(self, query: str, options: List[str],
                       lang: Optional[str] = None,
@@ -559,17 +680,12 @@ class MultipleChoiceSolver(AbstractSolver):
         :param return_index: If True, return the index of the best option; otherwise, return the best option text.
         :return: The best answer from the options list, or the index of the best option if `return_index` is True.
         """
-        best = self.rerank(query, options, lang=lang)[0][1]
-        if return_index:
-            return options.index(best)
-        return best
+        return self.rerank(query, options, lang=lang, return_index=return_index)[0][1]
 
 
 class EntailmentSolver(AbstractSolver):
     """ select best answer from question + multiple choice
     handling automatic translation back and forth as needed"""
-
-    # plugin methods to override
 
     @abc.abstractmethod
     def check_entailment(self, premise: str, hypothesis: str,
@@ -586,9 +702,9 @@ class EntailmentSolver(AbstractSolver):
 
     # user facing methods
     @_deprecate_context2lang()
+    @auto_detect_lang(text_keys=["premise", "hypothesis"])
     @auto_translate(translate_keys=["premise", "hypothesis"])
-    def entails(self, premise: str, hypothesis: str,
-                lang: Optional[str] = None) -> bool:
+    def entails(self, premise: str, hypothesis: str, lang: Optional[str] = None) -> bool:
         """
         Determine if the premise entails the hypothesis with automatic translation and caching if needed.
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,5 @@ pytest
 pytest-timeout
 pytest-cov
 ovos-translate-server-plugin
+ovos-classifiers
 ovos-utils>=0.1.0a8

--- a/test/unittests/test_solver.py
+++ b/test/unittests/test_solver.py
@@ -141,11 +141,11 @@ class TestQuestionSolverBaseMethods(unittest.TestCase):
         solver.translator.translate.return_value = "a wild translation appears"
 
         # no translation
-        ans = solver.spoken_answer("some query")
+        ans = solver.spoken_answer("some query", lang="en")
         solver.translator.translate.assert_not_called()
 
         # translation
-        ans = solver.spoken_answer("not english", context={"lang": "unk"})
+        ans = solver.spoken_answer("not english", lang="unk")
         solver.translator.translate.assert_called()
 
 

--- a/test/unittests/test_solver.py
+++ b/test/unittests/test_solver.py
@@ -1,8 +1,10 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
+from ovos_plugin_manager.templates.solvers import QuestionSolver, auto_detect_lang, auto_translate, _deprecate_context2lang, AbstractSolver
 from ovos_plugin_manager.utils import PluginTypes, PluginConfigTypes
-from ovos_plugin_manager.templates.solvers import QuestionSolver
+
+
 # TODO: Test Tldr, Evidence, MultipleChoice, Entailment
 
 
@@ -398,3 +400,76 @@ class TestReadingComprehensionSolver(unittest.TestCase):
             get_reading_comprehension_solver_supported_langs
         get_reading_comprehension_solver_supported_langs()
         get_supported_languages.assert_called_once_with(self.PLUGIN_TYPE)
+
+
+class TestAutoTranslate(unittest.TestCase):
+    def setUp(self):
+        self.solver = AbstractSolver(enable_tx=True, default_lang='en')
+        self.solver.translate = MagicMock(side_effect=lambda text, source_lang=None, target_lang=None: text[
+                                                                                                       ::-1] if source_lang and target_lang else text)
+
+    def test_auto_translate_decorator(self):
+        @auto_translate(translate_keys=['text'])
+        def test_func(solver, text, lang=None):
+            return text[::-1]
+
+        result = test_func(self.solver, 'hello', lang='es')
+        self.assertEqual(result, 'olleh')  # 'hello' reversed due to mock translation
+
+    def test_auto_translate_no_translation(self):
+        @auto_translate(translate_keys=['text'])
+        def test_func(solver, text, lang=None):
+            return text
+
+        result = test_func(self.solver, 'hello')
+        self.assertEqual(result, 'hello')
+
+
+class TestAutoDetectLang(unittest.TestCase):
+    def setUp(self):
+        self.solver = AbstractSolver()
+        self.solver.detect_language = MagicMock(return_value='en')
+
+    def test_auto_detect_lang_decorator(self):
+        self.solver.detector = Mock()
+        self.solver.detector.detect.return_value = "en"
+
+        @auto_detect_lang(text_keys=['text'])
+        def test_func(solver, text, lang=None):
+            return lang
+
+        result = test_func(self.solver, 'hello world')
+        self.assertEqual(result, 'en')
+
+    def test_auto_detect_lang_with_lang(self):
+        @auto_detect_lang(text_keys=['text'])
+        def test_func(solver, text, lang=None):
+            return lang
+
+        result = test_func(self.solver, 'hello', lang='es')
+        self.assertEqual(result, 'es')
+
+
+class TestDeprecateContext2Lang(unittest.TestCase):
+    def setUp(self):
+        self.solver = AbstractSolver()
+
+    def test_deprecate_context2lang(self):
+        @_deprecate_context2lang()
+        def test_func(solver, lang=None):
+            return lang
+
+        result = test_func(self.solver, context={'lang': 'en'})
+        self.assertEqual(result, 'en')
+
+    def test_no_context(self):
+        @_deprecate_context2lang()
+        def test_func(solver, lang=None):
+            return lang
+
+        result = test_func(self.solver, lang='fr')
+        self.assertEqual(result, 'fr')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- move class properties to init method
- move autotranslation logic to `@auto_translate()` decorator (easier to maintain, less convoluted code) 
- add language detector plugin
- add util methods `self.translate` and `self.detect_language`
- deprecate `context` kwarg, new `@_deprecate_context2lang` decorator handles migration into new kwarg `lang` if needed
- new util method ensure plugins with old signatures keep working `_call_with_sanitized_kwargs`
- improve docstrs and typing for solver and translations plugins


may fix issues around the language kwarg, i am not sure exactly which issues but we have intermittent reports seemingly related to this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced multilingual support with new parameters for language detection and translation in solver classes.
  - Automatic translation of inputs and outputs for various methods, improving user experience in multilingual contexts.

- **Improvements**
  - Deprecated the `context` parameter in favor of a clearer `lang` parameter across multiple methods, providing better guidance for users.

- **Documentation**
  - Expanded docstrings for methods to clarify their purpose and parameters, aiding user understanding.

- **Tests**
  - Updated test cases to accommodate the new language parameter in method calls, enhancing the clarity and maintainability of tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->