### PR TITLE
fix/context_kwarg_backwards_compat

### DIFF
--- a/ovos_plugin_manager/templates/solvers.py
+++ b/ovos_plugin_manager/templates/solvers.py
@@ -311,7 +311,7 @@ class QuestionSolver(AbstractSolver):
     @abc.abstractmethod
     def get_spoken_answer(self, query: str,
                           lang: Optional[str] = None,
-                          units: Optional[str] = None) -> str:
+                          units: Optional[str] = None) -> Optional[str]:
         """
         Obtain the spoken answer for a given query.
 
@@ -347,7 +347,7 @@ class QuestionSolver(AbstractSolver):
     @_deprecate_context2lang()
     def get_data(self, query: str,
                  lang: Optional[str] = None,
-                 units: Optional[str] = None) -> Optional[Dict]:
+                 units: Optional[str] = None) -> Optional[Dict[str, str]]:
         """
         Retrieve data for the given query.
 
@@ -381,7 +381,7 @@ class QuestionSolver(AbstractSolver):
     @_deprecate_context2lang()
     def get_expanded_answer(self, query: str,
                             lang: Optional[str] = None,
-                            units: Optional[str] = None) -> List[dict]:
+                            units: Optional[str] = None) -> List[Dict[str, str]]:
         """
         Get an expanded list of steps to elaborate on the answer.
 
@@ -403,7 +403,7 @@ class QuestionSolver(AbstractSolver):
     @auto_translate(translate_keys=["query"])
     def search(self, query: str,
                lang: Optional[str] = None,
-               units: Optional[str] = None) -> dict:
+               units: Optional[str] = None) -> Optional[Dict]:
         """
         Perform a search with automatic translation and caching.
 
@@ -441,7 +441,7 @@ class QuestionSolver(AbstractSolver):
     @auto_translate(translate_keys=["query"])
     def visual_answer(self, query: str,
                       lang: Optional[str] = None,
-                      units: Optional[str] = None) -> str:
+                      units: Optional[str] = None) -> Optional[str]:
         """
         Retrieve the image associated with the query with automatic translation and caching.
 
@@ -465,7 +465,7 @@ class QuestionSolver(AbstractSolver):
     @auto_translate(translate_keys=["query"])
     def spoken_answer(self, query: str,
                       lang: Optional[str] = None,
-                      units: Optional[str] = None) -> str:
+                      units: Optional[str] = None) -> Optional[str]:
         """
         Retrieve the spoken answer for the query with automatic translation and caching.
 
@@ -500,7 +500,7 @@ class QuestionSolver(AbstractSolver):
     @auto_translate(translate_keys=["query"])
     def long_answer(self, query: str,
                     lang: Optional[str] = None,
-                    units: Optional[str] = None) -> List[Dict]:
+                    units: Optional[str] = None) -> List[Dict[str, str]]:
         """
         Retrieve a detailed list of steps to expand the answer.
 
@@ -566,7 +566,7 @@ class CorpusSolver(QuestionSolver):
 
     @auto_detect_lang(text_keys=["query"])
     @auto_translate(translate_keys=["query"])
-    def get_spoken_answer(self, query: str, lang: Optional[str] = None) -> str:
+    def get_spoken_answer(self, query: str, lang: Optional[str] = None) -> Optional[str]:
         # Query the corpus
         answers = [a[1] for a in self.retrieve_from_corpus(query, lang=lang,
                                                            k=self.config.get("n_answer", 1))]
@@ -818,6 +818,10 @@ def _call_with_sanitized_kwargs(func, *args: Any,
     """
     params = inspect.signature(func).parameters
     kwargs = {}
+
+    # ensure context is passed, it didn't used to be optional
+    if "context" in params and "context" not in kwargs:
+        kwargs["context"] = {}
 
     if "lang" in params:
         # new style - only lang/units is passed


### PR DESCRIPTION
ensure "context" is passed to old plugins that still have it in their signature

improve typing

error logs without this PR (if ovos-plugin-manager is updated and wolfie skill isnt)
```
Aug 04 20:34:31 mark2 ovos-core[40710]: 2024-08-04 20:34:31.242 - skills - ovos_plugin_manager.templates.solvers:func_wrapper:123 - WARNING - Deprecation version=0.1.0. Caller=skill_ovos_wolfie:294. 'context' kwarg has been deprecated, please pass 'lang' as it's own kwarg instead
Aug 04 20:34:31 mark2 ovos-core[40710]: 2024-08-04 20:34:31.249 - skill-ovos-ddg.openvoiceos - DEBUG - skipping auto translation for DuckDuckGo, en-us is supported
Aug 04 20:34:31 mark2 ovos-core[40710]: 2024-08-04 20:34:31.305 - skills - ovos_workshop.skills.common_query_skill:__get_cq:170 - ERROR - error matching what is open Voice Oasis with skill-ovos-wolfie.openvoiceos
Aug 04 20:34:31 mark2 ovos-core[40710]: Traceback (most recent call last):
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_workshop/skills/common_query_skill.py", line 168, in __get_cq
Aug 04 20:34:31 mark2 ovos-core[40710]:     result = self.CQS_match_query_phrase(search_phrase)
Aug 04 20:34:31 mark2 ovos-core[40710]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/skill_ovos_wolfie/__init__.py", line 262, in CQS_match_query_phrase
Aug 04 20:34:31 mark2 ovos-core[40710]:     response = self.ask_the_wolf(phrase, sess.lang, sess.system_unit)
Aug 04 20:34:31 mark2 ovos-core[40710]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/skill_ovos_wolfie/__init__.py", line 294, in ask_the_wolf
Aug 04 20:34:31 mark2 ovos-core[40710]:     return self.wolfie.spoken_answer(query,
Aug 04 20:34:31 mark2 ovos-core[40710]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/templates/solvers.py", line 133, in func_wrapper
Aug 04 20:34:31 mark2 ovos-core[40710]:     return func(*args, **kwargs)
Aug 04 20:34:31 mark2 ovos-core[40710]:            ^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/templates/solvers.py", line 100, in func_wrapper
Aug 04 20:34:31 mark2 ovos-core[40710]:     return func(*args, **kwargs)
Aug 04 20:34:31 mark2 ovos-core[40710]:            ^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/templates/solvers.py", line 31, in func_wrapper
Aug 04 20:34:31 mark2 ovos-core[40710]:     return func(*args, **kwargs)
Aug 04 20:34:31 mark2 ovos-core[40710]:            ^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/templates/solvers.py", line 491, in spoken_answer
Aug 04 20:34:31 mark2 ovos-core[40710]:     summary = _call_with_sanitized_kwargs(self.get_spoken_answer, query, lang=lang, units=units)
Aug 04 20:34:31 mark2 ovos-core[40710]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]:   File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_plugin_manager/templates/solvers.py", line 836, in _call_with_sanitized_kwargs
Aug 04 20:34:31 mark2 ovos-core[40710]:     return func(*args, **kwargs)
Aug 04 20:34:31 mark2 ovos-core[40710]:            ^^^^^^^^^^^^^^^^^^^^^
Aug 04 20:34:31 mark2 ovos-core[40710]: TypeError: WolframAlphaSolver.get_spoken_answer() missing 1 required positional argument: 'context'
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved method return types to enhance clarity and type safety, indicating where a value may not always be available.
  
- **Bug Fixes**
	- Standardized return types across several methods to better handle cases of missing or optional values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->