### PR TITLE
feat:fallback_plugins

### DIFF
--- a/ovos_plugin_manager/g2p.py
+++ b/ovos_plugin_manager/g2p.py
@@ -107,6 +107,8 @@ class OVOSG2PFactory:
             "module": <engine_name>
         }
         """
+        if "g2p" in config:
+            config = config["g2p"]
         g2p_config = get_g2p_config(config)
         g2p_module = g2p_config.get('module', 'dummy')
         fallback = g2p_config.get("fallback_module")

--- a/ovos_plugin_manager/g2p.py
+++ b/ovos_plugin_manager/g2p.py
@@ -77,12 +77,6 @@ def get_g2p_config(config: Optional[dict] = None) -> dict:
 
 
 class OVOSG2PFactory:
-    """ replicates the base mycroft class, but uses only OPM enabled plugins"""
-    MAPPINGS = {
-        "dummy": "ovos-g2p-plugin-dummy",
-        "phoneme_guesser": "neon-g2p-plugin-phoneme-guesser",
-        "gruut": "neon-g2p-plugin-gruut"
-    }
 
     @staticmethod
     def get_class(config=None):
@@ -97,15 +91,13 @@ class OVOSG2PFactory:
         """
         config = get_g2p_config(config)
         g2p_module = config.get("module") or 'dummy'
-        if g2p_module in OVOSG2PFactory.MAPPINGS:
-            g2p_module = OVOSG2PFactory.MAPPINGS[g2p_module]
-        if g2p_module == 'ovos-g2p-plugin-dummy':
+        if g2p_module == 'dummy':
             return Grapheme2PhonemePlugin
 
         return load_g2p_plugin(g2p_module)
 
-    @staticmethod
-    def create(config=None):
+    @classmethod
+    def create(cls, config=None):
         """Factory method to create a G2P engine based on configuration.
 
         The configuration file ``mycroft.conf`` contains a ``g2p`` section with
@@ -117,11 +109,16 @@ class OVOSG2PFactory:
         """
         g2p_config = get_g2p_config(config)
         g2p_module = g2p_config.get('module', 'dummy')
+        fallback = g2p_config.get("fallback_module")
         try:
             clazz = OVOSG2PFactory.get_class(g2p_config)
             g2p = clazz(g2p_config)
             LOG.debug(f'Loaded plugin {g2p_module}')
         except Exception:
             LOG.exception('The selected G2P plugin could not be loaded.')
+            if fallback in config and fallback != g2p_module:
+                LOG.info(f"Attempting to load fallback plugin instead: {fallback}")
+                config["module"] = fallback
+                return cls.create(config)
             raise
         return g2p

--- a/ovos_plugin_manager/language.py
+++ b/ovos_plugin_manager/language.py
@@ -124,6 +124,7 @@ class OVOSLangDetectionFactory:
         cfg = config.get(lang_module, {})
         fallback = cfg.get("fallback_module")
         try:
+            config["module"] = lang_module
             clazz = OVOSLangDetectionFactory.get_class(config)
             if clazz is None:
                 raise ValueError(f"Failed to load module: {lang_module}")
@@ -180,6 +181,7 @@ class OVOSLangTranslationFactory:
         cfg = config.get(lang_module, {})
         fallback = cfg.get("fallback_module")
         try:
+            config["module"] = lang_module
             clazz = OVOSLangTranslationFactory.get_class(config)
             if clazz is None:
                 raise ValueError(f"Failed to load module: {lang_module}")

--- a/ovos_plugin_manager/language.py
+++ b/ovos_plugin_manager/language.py
@@ -83,24 +83,7 @@ def get_lang_detect_module_configs(module_name: str):
     return load_plugin_configs(module_name, PluginConfigTypes.LANG_DETECT)
 
 
-_fallback_lang_detect_plugin = "ovos-lang-detect-ngram-lm"
-_fallback_translate_plugin = "ovos-translate-plugin-server"
-
-
 class OVOSLangDetectionFactory:
-    """
-    replicates the base neon class, but uses only OPM enabled plugins
-    """
-    MAPPINGS = {
-        "libretranslate": "libretranslate_detection_plug",
-        "google": "googletranslate_detection_plug",
-        "amazon": "amazontranslate_detection_plug",
-        "cld2": "cld2_plug",
-        "cld3": "cld3_plug",
-        "langdetect": "langdetect_plug",
-        "fastlang": "fastlang_plug",
-        "lingua_podre": "lingua_podre_plug"
-    }
 
     @staticmethod
     def get_class(config=None):
@@ -120,12 +103,10 @@ class OVOSLangDetectionFactory:
         lang_module = config.get("detection_module", config.get("module"))
         if not lang_module:
             raise ValueError("`language.detection_module` not configured")
-        if lang_module in OVOSLangDetectionFactory.MAPPINGS:
-            lang_module = OVOSLangDetectionFactory.MAPPINGS[lang_module]
         return load_lang_detect_plugin(lang_module)
 
-    @staticmethod
-    def create(config=None) -> LanguageDetector:
+    @classmethod
+    def create(cls, config=None) -> LanguageDetector:
         """
         Factory method to create a LangDetection engine based on configuration
 
@@ -140,37 +121,25 @@ class OVOSLangDetectionFactory:
         if "language" in config:
             config = config["language"]
         lang_module = config.get("detection_module", config.get("module"))
+        cfg = config.get(lang_module, {})
+        fallback = cfg.get("fallback_module")
         try:
             clazz = OVOSLangDetectionFactory.get_class(config)
             if clazz is None:
                 raise ValueError(f"Failed to load module: {lang_module}")
             LOG.info(f'Loaded the Language Detection plugin {lang_module}')
-            if lang_module in OVOSLangDetectionFactory.MAPPINGS:
-                lang_module = OVOSLangDetectionFactory.MAPPINGS[lang_module]
             return clazz(config=get_plugin_config(config, "language",
                                                   lang_module))
         except Exception:
-            # The Language Detection backend failed to start, fall back if appropriate.
-            if lang_module != _fallback_lang_detect_plugin:
-                lang_module = _fallback_lang_detect_plugin
-                LOG.error(f'Language Detection plugin {lang_module} not found. '
-                          f'Falling back to {_fallback_lang_detect_plugin}')
-                clazz = load_lang_detect_plugin(_fallback_lang_detect_plugin)
-                if clazz:
-                    return clazz(config=get_plugin_config(config, "language",
-                                                          lang_module))
-            
+            LOG.exception(f'Language Detection plugin {lang_module} could not be loaded!')
+            if fallback in config and fallback != lang_module:
+                LOG.info(f"Attempting to load fallback plugin instead: {fallback}")
+                config["detection_module"] = fallback
+                return cls.create(config)
             raise
 
 
 class OVOSLangTranslationFactory:
-    """ replicates the base neon class, but uses only OPM enabled plugins"""
-    MAPPINGS = {
-        "libretranslate": "libretranslate_plug",
-        "google": "googletranslate_plug",
-        "amazon": "amazontranslate_plug",
-        "apertium": "apertium_plug"
-    }
 
     @staticmethod
     def get_class(config=None):
@@ -190,12 +159,10 @@ class OVOSLangTranslationFactory:
         lang_module = config.get("translation_module", config.get("module"))
         if not lang_module:
             raise ValueError("`language.translation_module` not configured")
-        if lang_module in OVOSLangTranslationFactory.MAPPINGS:
-            lang_module = OVOSLangTranslationFactory.MAPPINGS[lang_module]
         return load_tx_plugin(lang_module)
 
-    @staticmethod
-    def create(config=None) -> LanguageTranslator:
+    @classmethod
+    def create(cls, config=None) -> LanguageTranslator:
         """
         Factory method to create a LangTranslation engine based on configuration
 
@@ -210,24 +177,19 @@ class OVOSLangTranslationFactory:
         if "language" in config:
             config = config["language"]
         lang_module = config.get("translation_module", config.get("module"))
+        cfg = config.get(lang_module, {})
+        fallback = cfg.get("fallback_module")
         try:
             clazz = OVOSLangTranslationFactory.get_class(config)
             if clazz is None:
                 raise ValueError(f"Failed to load module: {lang_module}")
             LOG.info(f'Loaded the Language Translation plugin {lang_module}')
-            if lang_module in OVOSLangTranslationFactory.MAPPINGS:
-                lang_module = OVOSLangTranslationFactory.MAPPINGS[lang_module]
             return clazz(config=get_plugin_config(config, "language",
                                                   lang_module))
         except Exception:
-            # The Language Translation backend failed to start, fall back if appropriate.
-            if lang_module != _fallback_translate_plugin:
-                lang_module = _fallback_translate_plugin
-                LOG.error(f'Language Translation plugin {lang_module} '
-                          f'not found. Falling back to {_fallback_translate_plugin}')
-                clazz = load_tx_plugin(_fallback_translate_plugin)
-                if clazz:
-                    return clazz(config=get_plugin_config(config, "language",
-                                                          lang_module))
-
+            LOG.exception(f'Language Translation plugin {lang_module} could not be loaded!')
+            if fallback in config and fallback != lang_module:
+                LOG.info(f"Attempting to load fallback plugin instead: {fallback}")
+                config["translation_module"] = fallback
+                return cls.create(config)
             raise

--- a/ovos_plugin_manager/microphone.py
+++ b/ovos_plugin_manager/microphone.py
@@ -60,6 +60,8 @@ class OVOSMicrophoneFactory:
             "module": <engine_name>
         }
         """
+        if "microphone" in config:
+            config = config["microphone"]
         microphone_config = get_microphone_config(config)
         microphone_module = microphone_config.get('module')
         fallback = microphone_config.get("fallback_module")
@@ -70,7 +72,8 @@ class OVOSMicrophoneFactory:
             # as other plugin types
             microphone_config.pop('lang')
             microphone_config.pop('module')
-            microphone_config.pop('fallback_module')
+            if fallback:
+                microphone_config.pop('fallback_module')
             microphone = clazz(**microphone_config)
             LOG.debug(f'Loaded microphone plugin {microphone_module}')
         except Exception:

--- a/ovos_plugin_manager/microphone.py
+++ b/ovos_plugin_manager/microphone.py
@@ -49,8 +49,8 @@ class OVOSMicrophoneFactory:
         microphone_module = config.get("module")
         return load_microphone_plugin(microphone_module)
 
-    @staticmethod
-    def create(config=None):
+    @classmethod
+    def create(cls, config=None):
         """Factory method to create a microphone engine based on configuration.
 
         The configuration file ``mycroft.conf`` contains a ``microphone`` section with
@@ -62,6 +62,7 @@ class OVOSMicrophoneFactory:
         """
         microphone_config = get_microphone_config(config)
         microphone_module = microphone_config.get('module')
+        fallback = microphone_config.get("fallback_module")
         try:
             clazz = OVOSMicrophoneFactory.get_class(microphone_config)
             # Note that configuration is expanded for this class of plugins
@@ -69,9 +70,14 @@ class OVOSMicrophoneFactory:
             # as other plugin types
             microphone_config.pop('lang')
             microphone_config.pop('module')
+            microphone_config.pop('fallback_module')
             microphone = clazz(**microphone_config)
             LOG.debug(f'Loaded microphone plugin {microphone_module}')
         except Exception:
             LOG.exception('The selected microphone plugin could not be loaded.')
+            if fallback in config and fallback != microphone_module:
+                LOG.info(f"Attempting to load fallback plugin instead: {fallback}")
+                config["module"] = fallback
+                return cls.create(config)
             raise
         return microphone

--- a/ovos_plugin_manager/vad.py
+++ b/ovos_plugin_manager/vad.py
@@ -92,16 +92,19 @@ class OVOSVADFactory:
             "module": <engine_name>
         }
         """
-        vad_config = get_vad_config(config)
-        plugin = vad_config.get("module")
-        fallback = vad_config.get("fallback_module")
+        if "listener" in config:
+            config = config["listener"]
+        if "VAD" in config:
+            config = config["VAD"]
+        plugin = config.get("module")
         if not plugin:
-            raise ValueError(f"VAD Plugin not configured in: {vad_config}")
+            raise ValueError(f"VAD Plugin not configured in: {config}")
+
+        plugin_config = config.get(plugin, {})
+        fallback = plugin_config.get("fallback_module")
+
         try:
-            clazz = OVOSVADFactory.get_class(vad_config)
-            # module name not expected in config; don't change passed config
-            plugin_config = dict(vad_config)
-            plugin_config.pop("module")
+            clazz = OVOSVADFactory.get_class(config)
             return clazz(plugin_config)
         except Exception:
             LOG.exception(f'VAD plugin {plugin} could not be loaded!')

--- a/ovos_plugin_manager/wakewords.py
+++ b/ovos_plugin_manager/wakewords.py
@@ -105,14 +105,6 @@ def get_wws(scan=False):
 
 
 class OVOSWakeWordFactory:
-    """ replicates the base mycroft class, but uses only OPM enabled plugins"""
-    MAPPINGS = {
-        "dummy": "ovos-ww-plugin-dummy",
-        "pocketsphinx": "ovos-ww-plugin-pocketsphinx",
-        "precise": "ovos-ww-plugin-precise",
-        "snowboy": "ovos-ww-plugin-snowboy",
-        "porcupine": "porcupine_wakeword_plug"
-    }
 
     @staticmethod
     def get_class(hotword: str, config: Optional[dict] = None) -> type:
@@ -128,8 +120,6 @@ class OVOSWakeWordFactory:
                         f"Returning base HotWordEngine")
             return HotWordEngine
         ww_module = hotword_config[hotword]["module"]
-        if ww_module in OVOSWakeWordFactory.MAPPINGS:
-            ww_module = OVOSWakeWordFactory.MAPPINGS[ww_module]
         return load_wake_word_plugin(ww_module)
 
     @staticmethod

--- a/test/unittests/test_g2p.py
+++ b/test/unittests/test_g2p.py
@@ -131,12 +131,8 @@ class TestG2PFactory(unittest.TestCase):
 
         OVOSG2PFactory.create(config=_FALLBACK_CONFIG)
         mock_get_class.assert_called()
-        self.assertEqual(call_args, ({**_FALLBACK_CONFIG['g2p']['good'],
-                                      **{"module": "good",
-                                         "lang": "en-us"}},))
-        self.assertEqual(bad_call_args, ({**_FALLBACK_CONFIG['g2p']['bad'],
-                                          **{"module": "bad",
-                                             "lang": "en-us"}},))
+        self.assertEqual(call_args[0]["module"], 'good')
+        self.assertEqual(bad_call_args[0]["module"], 'bad')
         mock_class.assert_called_once_with({**_FALLBACK_CONFIG['g2p']['good'],
                                             **{"module": "good",
                                                "lang": "en-us"}})

--- a/test/unittests/test_g2p.py
+++ b/test/unittests/test_g2p.py
@@ -1,8 +1,23 @@
 import unittest
-
-from unittest.mock import patch
+from copy import deepcopy
 from enum import Enum
+from unittest.mock import patch, Mock
+
 from ovos_plugin_manager.utils import PluginTypes, PluginConfigTypes
+
+_TEST_CONFIG = {
+    "g2p": {
+        "module": "good",
+        "good": {"a": "b"}
+    }
+}
+_FALLBACK_CONFIG = {
+    "g2p": {
+        "module": "bad",
+        "bad": {"fallback_module": "good"},
+        "good": {"a": "b"}
+    }
+}
 
 
 class TestG2PTemplate(unittest.TestCase):
@@ -72,5 +87,57 @@ class TestG2P(unittest.TestCase):
 
 
 class TestG2PFactory(unittest.TestCase):
-    from ovos_plugin_manager.g2p import OVOSG2PFactory
-    # TODO
+    def test_create_g2p(self):
+        from ovos_plugin_manager.g2p import OVOSG2PFactory
+        real_get_class = OVOSG2PFactory.get_class
+        mock_class = Mock()
+        call_args = None
+
+        def _copy_args(*args):
+            nonlocal call_args
+            call_args = deepcopy(args)
+            return mock_class
+
+        mock_get_class = Mock(side_effect=_copy_args)
+        OVOSG2PFactory.get_class = mock_get_class
+
+        OVOSG2PFactory.create(config=_TEST_CONFIG)
+        mock_get_class.assert_called_once()
+        self.assertEqual(call_args, ({**_TEST_CONFIG['g2p']['good'],
+                                      **{"module": "good",
+                                         "lang": "en-us"}},))
+        mock_class.assert_called_once_with({**_TEST_CONFIG['g2p']['good'],
+                                            **{"module": "good",
+                                               "lang": "en-us"}})
+        OVOSG2PFactory.get_class = real_get_class
+
+    def test_create_fallback(self):
+        from ovos_plugin_manager.g2p import OVOSG2PFactory
+        real_get_class = OVOSG2PFactory.get_class
+        mock_class = Mock()
+        call_args = None
+        bad_call_args = None
+
+        def _copy_args(*args):
+            nonlocal call_args, bad_call_args
+            if args[0]["module"] == "bad":
+                bad_call_args = deepcopy(args)
+                return None
+            call_args = deepcopy(args)
+            return mock_class
+
+        mock_get_class = Mock(side_effect=_copy_args)
+        OVOSG2PFactory.get_class = mock_get_class
+
+        OVOSG2PFactory.create(config=_FALLBACK_CONFIG)
+        mock_get_class.assert_called()
+        self.assertEqual(call_args, ({**_FALLBACK_CONFIG['g2p']['good'],
+                                      **{"module": "good",
+                                         "lang": "en-us"}},))
+        self.assertEqual(bad_call_args, ({**_FALLBACK_CONFIG['g2p']['bad'],
+                                          **{"module": "bad",
+                                             "lang": "en-us"}},))
+        mock_class.assert_called_once_with({**_FALLBACK_CONFIG['g2p']['good'],
+                                            **{"module": "good",
+                                               "lang": "en-us"}})
+        OVOSG2PFactory.get_class = real_get_class

--- a/test/unittests/test_microphone.py
+++ b/test/unittests/test_microphone.py
@@ -182,12 +182,8 @@ class TestMicrophoneFactory(unittest.TestCase):
 
         OVOSMicrophoneFactory.create(config=_FALLBACK_CONFIG)
         mock_get_class.assert_called()
-        self.assertEqual(call_args, ({**_FALLBACK_CONFIG['microphone']['dummy'],
-                                      **{"module": "dummy",
-                                         "lang": "en-us"}},))
-        self.assertEqual(bad_call_args, ({**_FALLBACK_CONFIG['microphone']['bad'],
-                                      **{"module": "bad",
-                                         "lang": "en-us"}},))
+        self.assertEqual(call_args[0]["module"], 'dummy')
+        self.assertEqual(bad_call_args[0]["module"], 'bad')
         mock_class.assert_called_once_with(**_FALLBACK_CONFIG['microphone']['dummy'])
         OVOSMicrophoneFactory.get_class = real_get_class
 

--- a/test/unittests/test_wakewords.py
+++ b/test/unittests/test_wakewords.py
@@ -11,7 +11,7 @@ _TEST_CONFIG = {
             "active": True
         },
         "hey_mycroft": {
-            "module": "precise",
+            "module": "ovos-ww-plugin-precise",
             "listen": True,
             "active": True
         }
@@ -103,7 +103,7 @@ class TestWakeWordFactory(unittest.TestCase):
         OVOSWakeWordFactory.load_module = mock_load
 
         OVOSWakeWordFactory.create_hotword(config=_TEST_CONFIG)
-        mock_load.assert_called_once_with("precise", "hey_mycroft",
+        mock_load.assert_called_once_with("ovos-ww-plugin-precise", "hey_mycroft",
                                           _TEST_CONFIG["hotwords"]
                                           ['hey_mycroft'], "en-us", None)
 
@@ -148,7 +148,7 @@ class TestWakeWordFactory(unittest.TestCase):
         mock_return = Mock()
         mock_get_class.return_value = mock_return
         module = OVOSWakeWordFactory.load_module(
-            "precise", "hey_mycroft", _TEST_CONFIG['hotwords']['hey_mycroft'],
+            "ovos-ww-plugin-precise", "hey_mycroft", _TEST_CONFIG['hotwords']['hey_mycroft'],
             'en-us')
         mock_get_class.assert_called_once_with(
             "hey_mycroft", {"lang": "en-us", "hotwords": {


### PR DESCRIPTION
similar to WakeWords, allows defining a plugin to load if the primary fails

this is DIFFERENT from fallback TTS/STT, it isnt loaded at same time but instead when main plugin fails to load for any reason

companion to https://github.com/OpenVoiceOS/ovos-config/pull/153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced plugin loading mechanisms across various factories (G2P, Microphone, VAD, Language Detection, Language Translation) with fallback options for improved robustness.
	- Updated wake word module configuration to align with a new plugin system.

- **Bug Fixes**
	- Streamlined logic for loading plugins by removing unnecessary mappings, reducing complexity, and improving error handling.

- **Refactor**
	- Converted several static methods to class methods for better access to class-level properties and improved design principles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->