### PR TITLE
Update `config` default value handling with updated unit test

### DIFF
--- a/ovos_plugin_manager/utils/config.py
+++ b/ovos_plugin_manager/utils/config.py
@@ -27,16 +27,23 @@ def get_plugin_config(config: Optional[dict] = None, section: str = None,
     if module:
         module_config = dict(config.get(module) or dict())
         module_config.setdefault('module', module)
-        for key, val in config.items():
-            # Configured module name is not part of that module's config
-            if key in ("module", "translation_module", "detection_module"):
-                continue
-            elif isinstance(val, dict):
-                continue
-            # Use section-scoped config as defaults (i.e. TTS.lang)
-            module_config.setdefault(key, val)
+        if config == Configuration():
+            LOG.debug(f"No `{section}` config in Configuration")
+        else:
+            # If the config section exists (i.e. `stt`), then handle any default
+            # values in that section (i.e. `lang`)
+            for key, val in config.items():
+                # Configured module name is not part of that module's config
+                if key in ("module", "translation_module", "detection_module"):
+                    continue
+                elif isinstance(val, dict):
+                    continue
+                # Use section-scoped config as defaults (i.e. TTS.lang)
+                module_config.setdefault(key, val)
         config = module_config
     if section not in ["hotwords", "VAD", "listener", "gui"]:
+        # With some exceptions, plugins will want a `lang` value. If it was not
+        # set in the section or module config, use the default top-level config.
         config.setdefault('lang', lang)
     LOG.debug(f"Loaded configuration: {config}")
     return config

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -649,6 +649,12 @@ class TestConfigUtils(unittest.TestCase):
         self.assertEqual(tts_config['voice'], 'german-mbrola-5')
         self.assertNotIn("ovos_tts_plugin_espeakng", tts_config)
 
+        # Test PHAL with no configuration only `lang` is populated
+        phal_config = get_plugin_config(config, "PHAL")
+        self.assertEqual(set(phal_config.keys()), {"lang"})
+        phal_config = get_plugin_config(config, "PHAL", "test_plugin")
+        self.assertEqual(set(phal_config.keys()), {"lang"})
+
         self.assertEqual(_MOCK_CONFIG, start_config)
 
     def test_get_valid_plugin_configs(self):


### PR DESCRIPTION
Refactors `get_plugin_config` to prevent inserting extra top-level configuration when the specified `section` does not exist.
Related to #274 