### PR TITLE
fix: gui extensions homescreen init

### DIFF
--- a/ovos_plugin_manager/templates/gui.py
+++ b/ovos_plugin_manager/templates/gui.py
@@ -11,8 +11,12 @@ try:
 except ImportError as _exc:
 
     class HomescreenManager:
-        # delay exception until init is attempted, this may not necessarily be used
-        # also allows typing
+        """Fallback class when ovos-gui is not installed.
+
+        Raises the original ImportError when instantiated to
+        provide clear error messaging while still allowing type hints to work.
+        """
+
         def __init__(self, *args, **kwargs):
             LOG.error("you seem to be running GUIExtensions without ovos-gui installed...")
             # raise the original ImportError

--- a/ovos_plugin_manager/templates/gui.py
+++ b/ovos_plugin_manager/templates/gui.py
@@ -1,8 +1,22 @@
+from typing import Optional, Dict, Any
+
 from ovos_bus_client import Message
 from ovos_bus_client import MessageBusClient
 from ovos_bus_client.apis.gui import GUIInterface
-from ovos_utils.log import LOG
 from ovos_config import Configuration
+from ovos_utils.log import LOG
+
+try:
+    from ovos_gui.homescreen import HomescreenManager
+except ImportError as _exc:
+
+    class HomescreenManager:
+        # delay exception until init is attempted, this may not necessarily be used
+        # also allows typing
+        def __init__(self, *args, **kwargs):
+            LOG.error("you seem to be running GUIExtensions without ovos-gui installed...")
+            # raise the original ImportError
+            raise _exc
 
 
 class GUIExtension:
@@ -20,39 +34,40 @@ class GUIExtension:
         permanent (bool): disable unloading of GUI skills on gui client disconnections
     """
 
-    def __init__(self, config, bus=None, gui=None,
-                 preload_gui=False, permanent=False):
+    def __init__(self, config: Dict[str, Any],
+                 bus: Optional[MessageBusClient] = None,
+                 gui: Optional[GUIInterface] = None,
+                 preload_gui: bool = False,
+                 permanent: bool = False):
 
         if not bus:
             bus = MessageBusClient()
             bus.run_in_thread()
             bus.connected_event.wait()
-        self.bus = bus
-        self.gui = gui or GUIInterface("ovos.shell", bus=self.bus,
-                                       config=Configuration().get("gui", {}))
+        self.bus: MessageBusClient = bus
+        self.gui: GUIInterface = gui or GUIInterface("ovos.shell", bus=self.bus,
+                                                     config=Configuration().get("gui", {}))
         self.preload_gui = preload_gui
         self.permanent = permanent
         self.config = config
+        self.homescreen_manager: Optional[HomescreenManager] = None
         self.register_bus_events()
 
     def register_bus_events(self):
         self.bus.on("mycroft.gui.screen.close", self.handle_remove_namespace)
 
-    def bind_homescreen(self, homescreen=None):
+    def bind_homescreen(self, homescreen: Optional[HomescreenManager] = None):
         if self.config.get("homescreen_supported", False):
             if not homescreen:
-                # raise exception as usual if this fails
-                from ovos_gui.homescreen import HomescreenManager
-                homescreen = HomescreenManager(self.bus, self.gui)
+                LOG.debug("Loading HomescreenManager")
+                homescreen = HomescreenManager(self.bus)
                 homescreen.daemon = True
                 homescreen.start()
-
             self.homescreen_manager = homescreen
         else:
             LOG.info("Homescreen support not configured")
 
-    def handle_remove_namespace(self, message):
-        LOG.info("Got Clear Namespace Event In Skill")
+    def handle_remove_namespace(self, message: Message):
         get_skill_namespace = message.data.get("skill_id", "")
         if get_skill_namespace:
             self.bus.emit(Message("gui.clear.namespace",


### PR DESCRIPTION
was passing an extra kwarg

improve optional import handling and typing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved error handling with a fallback for the `HomescreenManager` import.
	- Enhanced type annotations for better clarity and type safety in the GUI extension.

- **Bug Fixes**
	- Fixed potential import errors by providing a fallback class definition.

- **Documentation**
	- Updated method signatures to include type hints for parameters, improving code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->