### PR TITLE
feat: STT lang detector

### DIFF
--- a/ovos_plugin_manager/templates/stt.py
+++ b/ovos_plugin_manager/templates/stt.py
@@ -38,12 +38,10 @@ class STT(metaclass=ABCMeta):
         self._detector = detector
         LOG.debug(f"{self.__class__.__name__} - Assigned lang detector: {detector}")
 
-    def detect_language(self, audio) -> str:
-        from speech_recognition import AudioData
-        assert isinstance(audio, AudioData)
+    def detect_language(self, audio) -> Tuple[str, float]:
         if self._detector is None:
             raise NotImplementedError(f"{self.__class__.__name__} does not support audio language detection")
-        return self._detector.detect(audio)
+        return self._detector.detect(audio, valid_langs=self.available_languages)
 
     @classproperty
     def runtime_requirements(self):
@@ -138,7 +136,7 @@ class STT(metaclass=ABCMeta):
         """transcribe audio data to a list of
         possible transcriptions and respective confidences"""
         if lang is not None and lang == "auto":
-            lang = self.detect_language(audio)
+            lang, prob = self.detect_language(audio)
         return [(self.execute(audio, lang), 1.0)]
 
     @property


### PR DESCRIPTION
allows STT plugins to detect the language from audio

most plugins don't support this, but some like whisper do and would otherwise require loading 2 models into memory

related: https://github.com/OpenVoiceOS/ovos-stt-http-server/pull/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced automatic language detection for audio transcription.
	- Added a method to bind a language detector to the speech-to-text functionality.
- **Bug Fixes**
	- Updated deprecation warnings for several STT classes to encourage subclassing from the new `STT` class.
- **Improvements**
	- Enhanced the `transcribe` method to utilize language detection when the language parameter is set to "auto."
	- Updated the `available_languages` property to reflect improved type hinting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->