### PR TITLE
feat: voice-clone plugin family (opm.vc)

### DIFF
--- a/docs/plugin-types.md
+++ b/docs/plugin-types.md
@@ -31,6 +31,7 @@ plugins expose supported-language configuration.
 | `INTENT_TRANSFORMER` | `opm.transformer.intent` | `IntentTransformer` |
 | `PHONEME` | `opm.g2p` | `Grapheme2PhonemePlugin` |
 | `AUDIO2IPA` | `opm.audio2ipa` | `Audio2IPAPlugin` |
+| `VOICE_CLONE` | `opm.vc` | `VoiceClonePlugin` |
 | `KEYWORD_EXTRACTION` | `opm.keywords` | `KeywordExtractor` |
 | `UTTERANCE_SEGMENTATION` | `opm.segmentation` | `UtteranceSegmenter` |
 | `TOKENIZATION` | `opm.tokenization` | `Tokenizer` |

--- a/docs/voice-clone.md
+++ b/docs/voice-clone.md
@@ -75,6 +75,5 @@ out_wav = cloner.clone_voice("/path/source.wav", "/path/reference.wav")
 
 ## Implementations
 
-**vconnx** — the first reference implementation built against this contract.
-It wraps an ONNX voice-conversion model and produces 16-bit WAV output at the model's
-native sample rate.  See the vconnx repository for installation and usage.
+Implementations register under the `opm.vc` entry-point group and are
+discovered with `find_voice_clone_plugins()`.

--- a/docs/voice-clone.md
+++ b/docs/voice-clone.md
@@ -1,0 +1,80 @@
+# Voice Cloning Plugins (`opm.vc`)
+
+Voice-cloning plugins perform **audio-to-audio** voice conversion: given a source
+speech file and a short reference speaker sample, the plugin outputs new audio that
+carries the linguistic content of the source but sounds like the reference speaker.
+
+> **Scope boundary — text input is out of scope.**  Voice cloning from text (zero-shot
+> TTS with a speaker reference) belongs in TTS plugins and is configured via the TTS
+> plugin's own `config` section.  The `opm.vc` family deals exclusively with
+> already-recorded speech as input; it never receives raw text.
+
+---
+
+## Contract
+
+Base class: `ovos_plugin_manager.templates.vc.VoiceClonePlugin`
+
+Entry-point group: `opm.vc`  
+Config section: `voice_clone`
+
+| Method / Property | Description |
+|---|---|
+| `clone_voice(audio, reference_voice, out_path=None) → str` | **Only abstract method.** Convert source WAV `audio` to the voice of `reference_voice`. Returns path to a 16-bit output WAV. |
+| `sample_rate → int` | Output sample rate in Hz (default 24000). Override to advertise the engine's native rate. |
+| `available_languages → List[str]` | BCP-47 tags supported. Return `[]` for language-agnostic engines (default). |
+
+`__init__(self, config=None)` stores the plugin-specific config dict; no further
+initialisation is mandated.
+
+---
+
+## Registering a Plugin
+
+```toml
+# pyproject.toml
+[project.entry-points."opm.vc"]
+my-vc-plugin = "my_package.vc:MyVoiceClonePlugin"
+```
+
+```json
+// mycroft.conf  (or equivalent OVOS config)
+{
+  "voice_clone": {
+    "module": "my-vc-plugin",
+    "my-vc-plugin": {
+      "model_path": "/path/to/model.onnx"
+    }
+  }
+}
+```
+
+---
+
+## Discovery and Factory API
+
+```python
+from ovos_plugin_manager.vc import (
+    find_voice_clone_plugins,
+    load_voice_clone_plugin,
+    OVOSVoiceClonerFactory,
+)
+
+# List all installed plugins
+plugins = find_voice_clone_plugins()  # dict: name -> class
+
+# Load a specific plugin class (not instantiated)
+cls = load_voice_clone_plugin("my-vc-plugin")
+
+# Instantiate from config
+cloner = OVOSVoiceClonerFactory.create(config)
+out_wav = cloner.clone_voice("/path/source.wav", "/path/reference.wav")
+```
+
+---
+
+## Implementations
+
+**vconnx** — the first reference implementation built against this contract.
+It wraps an ONNX voice-conversion model and produces 16-bit WAV output at the model's
+native sample rate.  See the vconnx repository for installation and usage.

--- a/ovos_plugin_manager/templates/vc.py
+++ b/ovos_plugin_manager/templates/vc.py
@@ -1,0 +1,124 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Abstract base class for voice-cloning (audio → audio) plugins."""
+import abc
+import os
+import tempfile
+from typing import Dict, List, Optional
+
+
+class VoiceClonePlugin(abc.ABC):
+    """Base class for voice-cloning plugins.
+
+    A voice-cloning plugin converts source speech audio to sound like a
+    reference speaker while preserving the linguistic content of the source.
+    This is a pure audio-to-audio contract: the plugin receives two audio
+    files and returns a new audio file.
+
+    Plugin authors must implement :meth:`clone_voice`.
+
+    Entry-point group: ``opm.vc``
+    Config section: ``voice_clone``
+
+    Example pyproject.toml registration::
+
+        [project.entry-points."opm.vc"]
+        my-vc-plugin = "my_package.vc:MyVoiceClonePlugin"
+
+    Attributes:
+        config: Plugin configuration dictionary passed at construction time.
+    """
+
+    def __init__(self, config: Optional[Dict] = None):
+        """Initialise the plugin with an optional configuration dictionary.
+
+        Args:
+            config: Plugin-specific configuration. Plugins may document their
+                supported keys in settingsmeta.json.
+        """
+        self.config: Dict = config or {}
+
+    # ------------------------------------------------------------------
+    # Required contract
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def clone_voice(
+        self,
+        audio: str,
+        reference_voice: str,
+        out_path: Optional[str] = None,
+    ) -> str:
+        """Convert source speech to sound like *reference_voice*.
+
+        Args:
+            audio: Path to the source speech WAV file whose linguistic
+                content should be preserved.
+            reference_voice: Path to a short reference WAV file that
+                provides the target voice timbre/style.
+            out_path: Desired output file path.  If ``None`` the
+                implementation should write to a temporary file and
+                return its path.
+
+        Returns:
+            Absolute path to the output 16-bit WAV file.  The sample rate
+            is documented by the plugin via :attr:`sample_rate`.
+
+        Raises:
+            NotImplementedError: Must be overridden by subclasses.
+        """
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Optional properties / helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def sample_rate(self) -> int:
+        """Output sample rate in Hz.
+
+        Plugins should override this to advertise the sample rate of the
+        WAV files they produce.  Defaults to 24000 Hz.
+        """
+        return 24000
+
+    @property
+    def available_languages(self) -> List[str]:
+        """BCP-47 language tags supported by this plugin.
+
+        Return an empty list (the default) for language-agnostic plugins
+        that operate on raw acoustic features regardless of language.
+        """
+        return []
+
+    # ------------------------------------------------------------------
+    # Convenience helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_output_path(out_path: Optional[str], suffix: str = ".wav") -> str:
+        """Return *out_path* if set, otherwise a fresh temporary file path.
+
+        Args:
+            out_path: Caller-supplied path or ``None``.
+            suffix: File extension for the temporary file.
+
+        Returns:
+            A writable file path.
+        """
+        if out_path:
+            os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+            return out_path
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        os.close(fd)
+        return path

--- a/ovos_plugin_manager/utils/__init__.py
+++ b/ovos_plugin_manager/utils/__init__.py
@@ -100,6 +100,7 @@ class PluginTypes(str, Enum):
     WEB_PLAYER = "opm.media.web"
     PERSONA = "opm.plugin.persona"  # personas are a dict, they have no config because they ARE a config
     AGENT_TOOLBOX = "opm.agents.toolbox"
+    VOICE_CLONE = "opm.vc"
 
     # solver plugins are deprecated!
     QUESTION_SOLVER = "opm.solver.question"
@@ -155,6 +156,7 @@ class PluginConfigTypes(str, Enum):
     AGENT_YES_NO = "opm.agents.yesno.config"
     AGENT_OPTION_MATCHER = "opm.agents.option_matcher.config"
     AGENT_TOOLBOX = "opm.agents.toolbox.config"
+    VOICE_CLONE = "opm.vc.config"
     KEYWORD_EXTRACTION = "opm.keywords.config"
     UTTERANCE_SEGMENTATION = "opm.segmentation.config"
     TOKENIZATION = "opm.tokenization.config"

--- a/ovos_plugin_manager/vc.py
+++ b/ovos_plugin_manager/vc.py
@@ -1,0 +1,116 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Discovery, loading, and factory helpers for voice-clone plugins (``opm.vc``)."""
+from typing import Dict, Optional, Type
+
+from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+from ovos_plugin_manager.utils import PluginTypes
+from ovos_utils.log import LOG
+
+
+def find_voice_clone_plugins() -> Dict[str, Type[VoiceClonePlugin]]:
+    """Find all installed voice-clone plugins.
+
+    Returns:
+        dict mapping plugin entry-point names to plugin classes.
+    """
+    from ovos_plugin_manager.utils import find_plugins
+    return find_plugins(PluginTypes.VOICE_CLONE)
+
+
+def load_voice_clone_plugin(module_name: str) -> Optional[Type[VoiceClonePlugin]]:
+    """Get an uninstantiated class for the requested voice-clone plugin.
+
+    Args:
+        module_name: Plugin entry-point name to load.
+
+    Returns:
+        Uninstantiated plugin class, or ``None`` if not found.
+    """
+    from ovos_plugin_manager.utils import load_plugin
+    return load_plugin(module_name, PluginTypes.VOICE_CLONE)
+
+
+def get_voice_clone_config(config: Optional[dict] = None,
+                           module: Optional[str] = None) -> dict:
+    """Get relevant configuration for factory methods.
+
+    Args:
+        config: Global ``mycroft.conf`` config dict, or a plugin-specific
+            config dict already scoped to the ``voice_clone`` section.
+        module: Voice-clone module name to retrieve config for.
+
+    Returns:
+        Plugin-specific configuration dict with at least a ``module`` key.
+    """
+    from ovos_plugin_manager.utils.config import get_plugin_config
+    return get_plugin_config(config, "voice_clone", module)
+
+
+class OVOSVoiceClonerFactory:
+    """Factory for instantiating voice-clone plugins from configuration.
+
+    Configuration is read from the ``voice_clone`` section of
+    ``mycroft.conf``::
+
+        "voice_clone": {
+            "module": "my-vc-plugin",
+            "my-vc-plugin": {
+                ...plugin-specific keys...
+            }
+        }
+    """
+
+    @staticmethod
+    def get_class(config: Optional[dict] = None) -> Optional[Type[VoiceClonePlugin]]:
+        """Return the plugin class specified by *config*.
+
+        Args:
+            config: Global or section-scoped configuration.  The
+                ``module`` key must be present (or resolvable via
+                :func:`get_voice_clone_config`).
+
+        Returns:
+            Uninstantiated :class:`~ovos_plugin_manager.templates.vc.VoiceClonePlugin`
+            subclass, or ``None`` if not found.
+        """
+        vc_config = get_voice_clone_config(config)
+        module = vc_config.get("module")
+        if not module:
+            return None
+        return load_voice_clone_plugin(module)
+
+    @staticmethod
+    def create(config: Optional[dict] = None) -> VoiceClonePlugin:
+        """Instantiate and return the configured voice-clone plugin.
+
+        Args:
+            config: Global or section-scoped configuration.
+
+        Returns:
+            An initialised :class:`~ovos_plugin_manager.templates.vc.VoiceClonePlugin`.
+
+        Raises:
+            RuntimeError: If the plugin class cannot be loaded.
+        """
+        vc_config = get_voice_clone_config(config)
+        module = vc_config.get("module")
+        plugin_config = vc_config.get(module) or {}
+        try:
+            clazz = OVOSVoiceClonerFactory.get_class(vc_config)
+            if clazz is None:
+                raise RuntimeError(f"Voice-clone plugin '{module}' could not be found.")
+            return clazz(plugin_config)
+        except Exception:
+            LOG.exception(f"The selected voice-clone plugin '{module}' could not be loaded!")
+            raise

--- a/test/unittests/test_vc.py
+++ b/test/unittests/test_vc.py
@@ -1,0 +1,286 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Unit tests for the voice-clone plugin family (opm.vc)."""
+import unittest
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+from ovos_plugin_manager.utils import PluginTypes, PluginConfigTypes
+
+
+# ---------------------------------------------------------------------------
+# Concrete minimal implementation used across tests
+# ---------------------------------------------------------------------------
+
+class _ConcreteVC:
+    """Minimal concrete implementation of VoiceClonePlugin for tests."""
+
+    def __init__(self, config=None):
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+        # Inherit dynamically so we can instantiate without import-time ABC machinery
+        self.config = config or {}
+
+    def clone_voice(self, audio: str, reference_voice: str,
+                    out_path: Optional[str] = None) -> str:
+        return out_path or "/tmp/cloned.wav"
+
+
+# ---------------------------------------------------------------------------
+# Template tests
+# ---------------------------------------------------------------------------
+
+class TestVoiceClonePluginTemplate(unittest.TestCase):
+    """Tests for ovos_plugin_manager.templates.vc.VoiceClonePlugin."""
+
+    def test_import(self):
+        """VoiceClonePlugin can be imported from the templates package."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+        self.assertTrue(callable(VoiceClonePlugin))
+
+    def test_is_abstract(self):
+        """VoiceClonePlugin is abstract — direct instantiation raises TypeError."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+        import abc
+        # clone_voice must be abstract
+        self.assertIn("clone_voice",
+                      getattr(VoiceClonePlugin, "__abstractmethods__", set()))
+
+    def test_exactly_one_abstract_method(self):
+        """VoiceClonePlugin has exactly one abstract method: clone_voice."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+        abstract_methods = getattr(VoiceClonePlugin, "__abstractmethods__", set())
+        self.assertEqual(abstract_methods, {"clone_voice"},
+                         "Contract violation: only clone_voice should be abstract")
+
+    def test_concrete_subclass_instantiates(self):
+        """A concrete subclass that implements clone_voice can be created."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _Impl(VoiceClonePlugin):
+            def clone_voice(self, audio, reference_voice, out_path=None):
+                return out_path or "/tmp/out.wav"
+
+        obj = _Impl(config={"key": "value"})
+        self.assertEqual(obj.config, {"key": "value"})
+
+    def test_clone_voice_returns_path(self):
+        """clone_voice returns the expected output path."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _Impl(VoiceClonePlugin):
+            def clone_voice(self, audio, reference_voice, out_path=None):
+                return out_path or "/tmp/out.wav"
+
+        obj = _Impl()
+        result = obj.clone_voice("/src.wav", "/ref.wav", "/out.wav")
+        self.assertEqual(result, "/out.wav")
+
+    def test_default_sample_rate(self):
+        """sample_rate defaults to 24000."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _Impl(VoiceClonePlugin):
+            def clone_voice(self, audio, reference_voice, out_path=None):
+                return "/tmp/out.wav"
+
+        obj = _Impl()
+        self.assertEqual(obj.sample_rate, 24000)
+
+    def test_custom_sample_rate(self):
+        """Subclasses can override sample_rate."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _Impl(VoiceClonePlugin):
+            sample_rate = 48000
+
+            def clone_voice(self, audio, reference_voice, out_path=None):
+                return "/tmp/out.wav"
+
+        obj = _Impl()
+        self.assertEqual(obj.sample_rate, 48000)
+
+    def test_available_languages_default(self):
+        """available_languages defaults to an empty list."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _Impl(VoiceClonePlugin):
+            def clone_voice(self, audio, reference_voice, out_path=None):
+                return "/tmp/out.wav"
+
+        obj = _Impl()
+        self.assertEqual(obj.available_languages, [])
+
+    def test_available_languages_custom(self):
+        """Subclasses can override available_languages."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _Impl(VoiceClonePlugin):
+            available_languages = ["pt-PT", "en-US"]
+
+            def clone_voice(self, audio, reference_voice, out_path=None):
+                return "/tmp/out.wav"
+
+        obj = _Impl()
+        self.assertIn("pt-PT", obj.available_languages)
+
+    def test_get_output_path_given(self):
+        """_get_output_path returns the provided path when not None."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+        import os, tempfile
+        with tempfile.TemporaryDirectory() as d:
+            target = os.path.join(d, "sub", "out.wav")
+            result = VoiceClonePlugin._get_output_path(target)
+            self.assertEqual(result, target)
+            self.assertTrue(os.path.isdir(os.path.dirname(result)))
+
+    def test_get_output_path_none(self):
+        """_get_output_path returns a valid temp path when None is passed."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+        import os
+        result = VoiceClonePlugin._get_output_path(None)
+        self.assertTrue(result.endswith(".wav"))
+        # Clean up the temp file
+        if os.path.exists(result):
+            os.unlink(result)
+
+    def test_abc_enforcement_no_clone_voice(self):
+        """Subclass missing clone_voice raises TypeError on instantiation."""
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _Broken(VoiceClonePlugin):
+            pass  # clone_voice not implemented
+
+        with self.assertRaises(TypeError):
+            _Broken()
+
+
+# ---------------------------------------------------------------------------
+# PluginTypes / PluginConfigTypes enum tests
+# ---------------------------------------------------------------------------
+
+class TestVoiceClonePluginTypes(unittest.TestCase):
+    """PluginTypes and PluginConfigTypes carry the correct opm.vc values."""
+
+    def test_plugin_type_value(self):
+        self.assertEqual(PluginTypes.VOICE_CLONE, "opm.vc")
+
+    def test_plugin_config_type_value(self):
+        self.assertEqual(PluginConfigTypes.VOICE_CLONE, "opm.vc.config")
+
+
+# ---------------------------------------------------------------------------
+# Discovery / loading module tests
+# ---------------------------------------------------------------------------
+
+class TestVoiceCloneModule(unittest.TestCase):
+    """Tests for ovos_plugin_manager.vc discovery and loading wrappers."""
+
+    @patch("ovos_plugin_manager.utils.find_plugins")
+    def test_find_voice_clone_plugins(self, mock_find: MagicMock) -> None:
+        """find_voice_clone_plugins calls find_plugins with VOICE_CLONE."""
+        from ovos_plugin_manager.vc import find_voice_clone_plugins
+        mock_find.return_value = {}
+        find_voice_clone_plugins()
+        mock_find.assert_called_once_with(PluginTypes.VOICE_CLONE)
+
+    @patch("ovos_plugin_manager.utils.load_plugin")
+    def test_load_voice_clone_plugin(self, mock_load: MagicMock) -> None:
+        """load_voice_clone_plugin calls load_plugin with VOICE_CLONE."""
+        from ovos_plugin_manager.vc import load_voice_clone_plugin
+        mock_load.return_value = MagicMock()
+        load_voice_clone_plugin("test-vc-plugin")
+        mock_load.assert_called_once_with("test-vc-plugin", PluginTypes.VOICE_CLONE)
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
+
+_FACTORY_CONFIG = {
+    "voice_clone": {
+        "module": "dummy-vc",
+        "dummy-vc": {
+            "model_path": "/models/dummy.onnx",
+        },
+    }
+}
+
+
+class TestOVOSVoiceClonerFactory(unittest.TestCase):
+    """Tests for OVOSVoiceClonerFactory."""
+
+    def test_get_class(self):
+        """get_class returns the class loaded by load_voice_clone_plugin."""
+        from ovos_plugin_manager.vc import OVOSVoiceClonerFactory, load_voice_clone_plugin
+        mock_cls = MagicMock()
+        real_load = load_voice_clone_plugin.__module__
+
+        with patch("ovos_plugin_manager.vc.load_voice_clone_plugin",
+                   return_value=mock_cls) as mock_load:
+            with patch("ovos_plugin_manager.vc.get_voice_clone_config",
+                       return_value={"module": "dummy-vc"}):
+                result = OVOSVoiceClonerFactory.get_class(_FACTORY_CONFIG)
+        self.assertIs(result, mock_cls)
+
+    def test_get_class_no_module_returns_none(self):
+        """get_class returns None when no module is configured."""
+        from ovos_plugin_manager.vc import OVOSVoiceClonerFactory
+        with patch("ovos_plugin_manager.vc.get_voice_clone_config",
+                   return_value={}):
+            result = OVOSVoiceClonerFactory.get_class({})
+        self.assertIsNone(result)
+
+    def test_create_instantiates_plugin(self):
+        """create() returns an instance of the plugin class."""
+        from ovos_plugin_manager.vc import OVOSVoiceClonerFactory
+        from ovos_plugin_manager.templates.vc import VoiceClonePlugin
+
+        class _DummyVC(VoiceClonePlugin):
+            def clone_voice(self, audio, reference_voice, out_path=None):
+                return out_path or "/tmp/out.wav"
+
+        with patch("ovos_plugin_manager.vc.get_voice_clone_config",
+                   return_value={"module": "dummy-vc", "dummy-vc": {"x": 1}}):
+            with patch("ovos_plugin_manager.vc.OVOSVoiceClonerFactory.get_class",
+                       return_value=_DummyVC):
+                instance = OVOSVoiceClonerFactory.create(_FACTORY_CONFIG)
+        self.assertIsInstance(instance, _DummyVC)
+        self.assertEqual(instance.config, {"x": 1})
+
+    def test_create_raises_when_class_none(self):
+        """create() raises RuntimeError when the plugin class cannot be found."""
+        from ovos_plugin_manager.vc import OVOSVoiceClonerFactory
+        with patch("ovos_plugin_manager.vc.get_voice_clone_config",
+                   return_value={"module": "missing-plugin"}):
+            with patch("ovos_plugin_manager.vc.OVOSVoiceClonerFactory.get_class",
+                       return_value=None):
+                with self.assertRaises(RuntimeError):
+                    OVOSVoiceClonerFactory.create({})
+
+    def test_create_propagates_exception(self):
+        """create() re-raises when plugin construction fails."""
+        from ovos_plugin_manager.vc import OVOSVoiceClonerFactory
+
+        def _exploding(*a, **kw):
+            raise ValueError("bad config")
+
+        with patch("ovos_plugin_manager.vc.get_voice_clone_config",
+                   return_value={"module": "dummy-vc", "dummy-vc": {}}):
+            with patch("ovos_plugin_manager.vc.OVOSVoiceClonerFactory.get_class",
+                       return_value=_exploding):
+                with self.assertRaises(ValueError):
+                    OVOSVoiceClonerFactory.create({})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `VoiceClonePlugin` ABC in `ovos_plugin_manager/templates/vc.py` — pure **audio-to-audio** contract. Text input is out of scope for this family; zero-shot TTS-with-speaker-reference belongs in TTS plugins.
- Adds `ovos_plugin_manager/vc.py`: `find_voice_clone_plugins`, `load_voice_clone_plugin`, `get_voice_clone_config`, `OVOSVoiceClonerFactory`.
- Registers `PluginTypes.VOICE_CLONE = "opm.vc"` and `PluginConfigTypes.VOICE_CLONE = "opm.vc.config"`.
- 21 unit tests covering ABC enforcement (including "exactly one abstract method"), enum values, discovery, and factory paths.
- Docs: `VOICE_CLONE` row in `docs/plugin-types.md`; new `docs/voice-clone.md` with scope boundary, full contract table, registration example.

## Pinned contract

Entry-point group: `opm.vc` · config section: `voice_clone`

Single abstract method: `clone_voice(audio: str, reference_voice: str, out_path: Optional[str] = None) -> str`

## How to test

```
pytest test/unittests/test_vc.py -v
# 21 passed in 2.40s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced voice cloning plugin framework for audio-to-audio voice conversion with configurable sample rates and language support.
  * Added plugin discovery system and factory for instantiating voice clone plugins.

* **Documentation**
  * Documented voice clone plugin API, contracts, and implementation requirements.
  * Added configuration and registration guidance for voice cloning plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->