### PR TITLE
fix: correct ovos.plugin.VAD alias to canonical opm.VAD

### DIFF
--- a/ovos_plugin_manager/utils/__init__.py
+++ b/ovos_plugin_manager/utils/__init__.py
@@ -25,7 +25,7 @@ DEPRECATED_ENTRYPOINTS = {
     "ovos.plugin.phal.admin": "opm.phal.admin",
     "ovos.plugin.skill": "opm.skill",
     "ovos.plugin.microphone": "opm.microphone",
-    "ovos.plugin.VAD": "opm.vad",
+    "ovos.plugin.VAD": "opm.VAD",
     "ovos.plugin.g2p": "opm.g2p",
     "ovos.plugin.audio2ipa": "opm.audio2ipa",
     'mycroft.plugin.stt': "opm.stt",


### PR DESCRIPTION
`DEPRECATED_ENTRYPOINTS["ovos.plugin.VAD"]` mapped to `opm.vad`, but `PluginTypes.VAD` = `opm.VAD` (capital) and `find_vad_plugins()` calls `find_plugins(PluginTypes.VAD)`. The case mismatch meant any VAD plugin still declaring the deprecated `ovos.plugin.VAD` group aliased to `opm.vad` — a group the finder never queries — so it would silently not be discovered. Align the alias to the canonical `opm.VAD`.