### PR TITLE
feat: first-class tool calls in the agent message/chat contract

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -95,15 +95,37 @@ Each `AgentTool` (`agent_tools.py:40`) carries:
 | `ovos-chat-multimodal-kilo-plugin` | `KiloMultimodalChatEngine` | Kilo | `ovos-kilo-plugin` |
 | `ovos-chat-multimodal-qwen-code-plugin` | `QwenCodeMultimodalChatEngine` | Qwen-Code | `ovos-qwen-code-plugin` |
 
-`ChatEngine.continue_chat` signature — `agents.py:210`:
+`ChatEngine.continue_chat` signature:
 ```python
 def continue_chat(self, messages: List[AgentMessage],
                   session_id: str = "default",
                   lang: Optional[str] = None,
-                  units: Optional[str] = None) -> AgentMessage:
+                  units: Optional[str] = None,
+                  tools: Optional[List[Dict[str, Any]]] = None) -> AgentMessage:
 ```
 
-`ChatEngine` also provides `stream_tokens`, `stream_sentences`, and `get_response` helpers (`agents.py:228–300`). Plugins only need to implement `continue_chat`.
+`ChatEngine` also provides `stream_tokens`, `stream_sentences`, and `get_response` helpers. Plugins only need to implement `continue_chat`.
+
+### Tool calling
+
+A conversation can carry tool turns. `MessageRole.TOOL` is the role of a tool
+result, and `AgentMessage` carries optional tool fields:
+
+- `tool_calls: Optional[List[ToolCall]]` — set on an `ASSISTANT` message that
+  requests tool invocations (`ToolCall(id, name, arguments)`); `content` may be `""`.
+- `tool_call_id` / `name` — set on a `TOOL` message, identifying the `ToolCall` it
+  answers.
+
+`continue_chat` accepts an optional `tools` argument (OpenAI `tools` spec — see
+[`agent-tools.md`](agent-tools.md)). An engine that can use it sets the class
+attribute `supports_tools = True` and returns an assistant `AgentMessage` whose
+`tool_calls` are populated when the model requests them. Engines that don't support
+tools leave `supports_tools = False` and ignore the argument — the new kwarg is
+optional, so pre-existing 4-arg `continue_chat` overrides keep working unchanged.
+The ordering invariant providers expect: an assistant message carrying `tool_calls`
+must be followed by one `TOOL` message per `ToolCall.id`. The orchestration loop
+that drives this lives in `ovos-agentic-loop` (`NativeToolCallEngine`), not in the
+provider engines.
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -116,10 +116,12 @@ result, and `AgentMessage` carries optional tool fields:
 - `tool_call_id` / `name` — set on a `TOOL` message, identifying the `ToolCall` it
   answers.
 
-`continue_chat` accepts an optional `tools` argument (OpenAI `tools` spec — see
-[`agent-tools.md`](agent-tools.md)). An engine that can use it sets the class
-attribute `supports_tools = True` and returns an assistant `AgentMessage` whose
-`tool_calls` are populated when the model requests them. Engines that don't support
+`continue_chat` accepts an optional `tools` argument — pass `ToolBox` object(s)
+directly (preferred) and/or OpenAI tool dicts; the engine coerces it with
+`ToolBox.normalize_tools(tools)` (see [`api/agent-tools.md`](api/agent-tools.md)).
+An engine that can use it sets the class attribute `supports_tools = True` and
+returns an assistant `AgentMessage` whose `tool_calls` are populated when the model
+requests them. Engines that don't support
 tools leave `supports_tools = False` and ignore the argument — the new kwarg is
 optional, so pre-existing 4-arg `continue_chat` overrides keep working unchanged.
 The ordering invariant providers expect: an assistant message carrying `tool_calls`

--- a/docs/api/agent-tools.md
+++ b/docs/api/agent-tools.md
@@ -62,7 +62,14 @@ def tools_to_openai_spec(tool_json_list: List[Dict]) -> List[Dict]   # neutral c
 
 @property
 def openai_tools(self) -> List[Dict]                                  # == tools_to_openai_spec(self.tool_json_list)
+
+@staticmethod
+def normalize_tools(tools) -> List[Dict]   # ToolBox(es) and/or dicts -> OpenAI spec list
 ```
+
+`normalize_tools` is what `ChatEngine`s call on their `tools` argument: it accepts a
+`ToolBox` (preferred), an OpenAI tool dict, or a list mixing either (or `None`), and
+returns a flat OpenAI spec list — so callers can pass toolbox objects directly.
 
 `tools_to_openai_spec` converts `tool_json_list` entries into the OpenAI
 `tools`/function-calling shape (`{"type": "function", "function": {"name",

--- a/docs/api/agent-tools.md
+++ b/docs/api/agent-tools.md
@@ -54,6 +54,25 @@ def tool_json_list(self) -> List[Dict]
 
 Returns all tools serialized with JSON Schema argument/output schemas — suitable for sending to an LLM's `tools` API parameter.
 
+**OpenAI tools spec:**
+
+```python
+@staticmethod
+def tools_to_openai_spec(tool_json_list: List[Dict]) -> List[Dict]   # neutral converter
+
+@property
+def openai_tools(self) -> List[Dict]                                  # == tools_to_openai_spec(self.tool_json_list)
+```
+
+`tools_to_openai_spec` converts `tool_json_list` entries into the OpenAI
+`tools`/function-calling shape (`{"type": "function", "function": {"name",
+"description", "parameters"}}`, where `parameters` is the tool's
+`argument_schema`). This is the de-facto interchange format across providers
+(OpenAI, Ollama, llama.cpp, vLLM, …); each `ChatEngine` re-maps from it to its own
+provider format. It is a `@staticmethod` so callers can convert schemas merged from
+several toolboxes (as the `ovos-agentic-loop` `NativeToolCallEngine` does); use the
+`openai_tools` property for a single toolbox.
+
 ---
 
 ## Messagebus Interface

--- a/ovos_plugin_manager/templates/agent_tools.py
+++ b/ovos_plugin_manager/templates/agent_tools.py
@@ -310,6 +310,42 @@ class ToolBox(ABC):
             for tool in self.tools.values()
         ]
 
+    @staticmethod
+    def tools_to_openai_spec(tool_json_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Convert ``tool_json_list`` entries to the OpenAI ``tools`` spec.
+
+        The OpenAI ``tools``/function-calling shape is the de-facto interchange
+        format across providers (OpenAI, Ollama, llama.cpp, vLLM, …); each
+        ChatEngine re-maps from this neutral spec to its own provider format.
+        Static so callers can convert merged schemas from several toolboxes.
+
+        Args:
+            tool_json_list: Entries shaped like :attr:`tool_json_list` —
+                ``{"name", "description", "argument_schema", "output_schema"}``.
+
+        Returns:
+            ``[{"type": "function", "function": {"name", "description",
+            "parameters"}}]`` where ``parameters`` is the tool's
+            ``argument_schema`` JSON Schema.
+        """
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool.get("description", ""),
+                    "parameters": tool.get("argument_schema",
+                                           {"type": "object", "properties": {}}),
+                },
+            }
+            for tool in tool_json_list
+        ]
+
+    @property
+    def openai_tools(self) -> List[Dict[str, Any]]:
+        """This toolbox's tools as an OpenAI ``tools`` spec (see ``tools_to_openai_spec``)."""
+        return self.tools_to_openai_spec(self.tool_json_list)
+
     # The only mandatory method for concrete plugins to implement
     @abstractmethod
     def discover_tools(self) -> List[AgentTool]:

--- a/ovos_plugin_manager/templates/agent_tools.py
+++ b/ovos_plugin_manager/templates/agent_tools.py
@@ -346,6 +346,36 @@ class ToolBox(ABC):
         """This toolbox's tools as an OpenAI ``tools`` spec (see ``tools_to_openai_spec``)."""
         return self.tools_to_openai_spec(self.tool_json_list)
 
+    @staticmethod
+    def normalize_tools(
+            tools: "Union[None, ToolBox, Dict[str, Any], List[Union[ToolBox, Dict[str, Any]]]]"
+    ) -> List[Dict[str, Any]]:
+        """Coerce tool input into the OpenAI ``tools`` spec list.
+
+        Lets callers pass ``ToolBox`` objects directly (preferred) or
+        already-built OpenAI tool dicts, or any mix in a list. ChatEngines call
+        this on their ``tools`` argument so they accept both forms uniformly.
+
+        Args:
+            tools: A ``ToolBox``, an OpenAI tool dict, a list mixing either, or None.
+
+        Returns:
+            A flat list of OpenAI tool/function spec dicts (empty for None).
+        """
+        if tools is None:
+            return []
+        if isinstance(tools, ToolBox):
+            return tools.openai_tools
+        if isinstance(tools, dict):
+            return [tools]
+        specs: List[Dict[str, Any]] = []
+        for t in tools:
+            if isinstance(t, ToolBox):
+                specs.extend(t.openai_tools)
+            else:  # already an OpenAI tool dict
+                specs.append(t)
+        return specs
+
     # The only mandatory method for concrete plugins to implement
     @abstractmethod
     def discover_tools(self) -> List[AgentTool]:

--- a/ovos_plugin_manager/templates/agents.py
+++ b/ovos_plugin_manager/templates/agents.py
@@ -17,6 +17,21 @@ class MessageRole(str, Enum):
     DEVELOPER = "developer"  # High-priority instructions (OpenAI specific)
     USER = "user"  # Human/End-user input
     ASSISTANT = "assistant"  # AI response
+    TOOL = "tool"  # Result of a tool/function call, replying to an assistant tool_call
+
+
+@dataclass
+class ToolCall:
+    """A single tool/function invocation requested by the assistant.
+
+    Attributes:
+        id (str): Provider-assigned call id, echoed back on the matching TOOL result.
+        name (str): Tool name; matches an ``AgentTool.name`` / ``ToolBox`` tool.
+        arguments (Dict[str, Any]): Parsed keyword arguments for ``ToolBox.call_tool``.
+    """
+    id: str
+    name: str
+    arguments: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -26,10 +41,19 @@ class AgentMessage:
 
     Attributes:
         role (MessageRole): The role of the message sender, e.g., MessageRole.USER.
-        content (str): The textual content of the message.
+        content (str): The textual content of the message (may be "" on an
+            assistant turn that only requests tool calls).
+        tool_calls (Optional[List[ToolCall]]): Set on ASSISTANT messages that
+            request one or more tool invocations.
+        tool_call_id (Optional[str]): Set on a TOOL message; matches the
+            ``ToolCall.id`` it is answering.
+        name (Optional[str]): Tool name on a TOOL message (OpenAI compatibility).
     """
     role: MessageRole
     content: str
+    tool_calls: Optional[List["ToolCall"]] = None
+    tool_call_id: Optional[str] = None
+    name: Optional[str] = None
 
 
 class AgentContextManager(ABC):
@@ -206,11 +230,16 @@ class ChatEngine(AbstractAgentEngine):
      ChatEngine plugins are responsible for filtering any unsupported roles
     """
 
+    # Whether this engine can consume the ``tools`` argument and return
+    # ``AgentMessage.tool_calls``. Tool-aware engines override this to True.
+    supports_tools: bool = False
+
     @abc.abstractmethod
     def continue_chat(self, messages: List[AgentMessage],
                       session_id: str = "default",
                       lang: Optional[str] = None,
-                      units: Optional[str] = None) -> AgentMessage:
+                      units: Optional[str] = None,
+                      tools: Optional[List[Dict[str, Any]]] = None) -> AgentMessage:
         """
         Generate a response message based on the provided chat history.
 
@@ -219,6 +248,10 @@ class ChatEngine(AbstractAgentEngine):
             session_id (str): Identifier for the session.
             lang (str, optional): BCP-47 language code.
             units (str, optional): Preferred unit system (e.g., "metric", "imperial").
+            tools (list, optional): Tool/function specs (OpenAI ``tools`` shape, e.g.
+                from ``ToolBox.tools_to_openai_spec`` / ``ToolBox.openai_tools``).
+                Only honored when ``supports_tools`` is True; the returned message may
+                carry ``tool_calls``.
 
         Returns:
             AgentMessage: The generated response message from the assistant.
@@ -316,7 +349,8 @@ class MultimodalChatEngine(ChatEngine):
     def continue_chat(self, messages: List[MultimodalAgentMessage],
                       session_id: str = "default",
                       lang: Optional[str] = None,
-                      units: Optional[str] = None) -> MultimodalAgentMessage:
+                      units: Optional[str] = None,
+                      tools: Optional[List[Dict[str, Any]]] = None) -> MultimodalAgentMessage:
         """
         Generate a response message based on the provided chat history.
 
@@ -325,6 +359,7 @@ class MultimodalChatEngine(ChatEngine):
             session_id (str): Identifier for the session.
             lang (str, optional): BCP-47 language code.
             units (str, optional): Preferred unit system (e.g., "metric", "imperial").
+            tools (list, optional): Tool/function specs; see ``ChatEngine.continue_chat``.
 
         Returns:
             AgentMessage: The generated response message from the assistant.

--- a/ovos_plugin_manager/templates/agents.py
+++ b/ovos_plugin_manager/templates/agents.py
@@ -4,11 +4,18 @@ import time
 from abc import ABC
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, List, Iterable, Tuple, Union, Dict, Any
+from typing import Optional, List, Iterable, Tuple, Union, Dict, Any, TYPE_CHECKING
 
 from ovos_bus_client.session import SessionManager, Session
 from ovos_spec_tools import standardize_lang
 from ovos_utils.log import LOG
+
+if TYPE_CHECKING:
+    from ovos_plugin_manager.templates.agent_tools import ToolBox
+
+# A ChatEngine ``tools`` argument: a ToolBox object (preferred), an OpenAI tool
+# dict, or a list mixing either. Engines call ``ToolBox.normalize_tools`` on it.
+ToolsArg = Optional[Union["ToolBox", Dict[str, Any], List[Union["ToolBox", Dict[str, Any]]]]]
 
 
 class MessageRole(str, Enum):
@@ -239,7 +246,7 @@ class ChatEngine(AbstractAgentEngine):
                       session_id: str = "default",
                       lang: Optional[str] = None,
                       units: Optional[str] = None,
-                      tools: Optional[List[Dict[str, Any]]] = None) -> AgentMessage:
+                      tools: "ToolsArg" = None) -> AgentMessage:
         """
         Generate a response message based on the provided chat history.
 
@@ -248,10 +255,11 @@ class ChatEngine(AbstractAgentEngine):
             session_id (str): Identifier for the session.
             lang (str, optional): BCP-47 language code.
             units (str, optional): Preferred unit system (e.g., "metric", "imperial").
-            tools (list, optional): Tool/function specs (OpenAI ``tools`` shape, e.g.
-                from ``ToolBox.tools_to_openai_spec`` / ``ToolBox.openai_tools``).
-                Only honored when ``supports_tools`` is True; the returned message may
-                carry ``tool_calls``.
+            tools: ``ToolBox`` object(s) (preferred) and/or OpenAI tool dicts to
+                expose to the model. Pass it straight through
+                ``ToolBox.normalize_tools(tools)`` to get the OpenAI spec list.
+                Only honored when ``supports_tools`` is True; the returned message
+                may carry ``tool_calls``.
 
         Returns:
             AgentMessage: The generated response message from the assistant.
@@ -350,7 +358,7 @@ class MultimodalChatEngine(ChatEngine):
                       session_id: str = "default",
                       lang: Optional[str] = None,
                       units: Optional[str] = None,
-                      tools: Optional[List[Dict[str, Any]]] = None) -> MultimodalAgentMessage:
+                      tools: "ToolsArg" = None) -> MultimodalAgentMessage:
         """
         Generate a response message based on the provided chat history.
 
@@ -359,7 +367,7 @@ class MultimodalChatEngine(ChatEngine):
             session_id (str): Identifier for the session.
             lang (str, optional): BCP-47 language code.
             units (str, optional): Preferred unit system (e.g., "metric", "imperial").
-            tools (list, optional): Tool/function specs; see ``ChatEngine.continue_chat``.
+            tools: ToolBox object(s) and/or OpenAI tool dicts; see ``ChatEngine.continue_chat``.
 
         Returns:
             AgentMessage: The generated response message from the assistant.

--- a/test/unittests/test_agent_tools.py
+++ b/test/unittests/test_agent_tools.py
@@ -228,6 +228,29 @@ class TestToolsToOpenAISpec(unittest.TestCase):
         self.assertEqual(spec, ToolBox.tools_to_openai_spec(tb.tool_json_list))
 
 
+class TestNormalizeTools(unittest.TestCase):
+    def test_none(self):
+        self.assertEqual(ToolBox.normalize_tools(None), [])
+
+    def test_single_toolbox(self):
+        tb = MathToolBox()
+        self.assertEqual(ToolBox.normalize_tools(tb), tb.openai_tools)
+
+    def test_single_dict(self):
+        spec = {"type": "function", "function": {"name": "x"}}
+        self.assertEqual(ToolBox.normalize_tools(spec), [spec])
+
+    def test_list_of_toolboxes(self):
+        tb = MathToolBox()
+        self.assertEqual(ToolBox.normalize_tools([tb]), tb.openai_tools)
+
+    def test_mixed_list(self):
+        tb = MathToolBox()
+        extra = {"type": "function", "function": {"name": "x"}}
+        out = ToolBox.normalize_tools([tb, extra])
+        self.assertEqual(out, tb.openai_tools + [extra])
+
+
 class TestToolBoxBusHandlers(unittest.TestCase):
     def setUp(self):
         self.bus = FakeBus()

--- a/test/unittests/test_agent_tools.py
+++ b/test/unittests/test_agent_tools.py
@@ -201,6 +201,33 @@ class TestToolJsonList(unittest.TestCase):
         self.assertEqual(tb.tool_json_list, [])
 
 
+class TestToolsToOpenAISpec(unittest.TestCase):
+    def test_staticmethod_shape(self):
+        spec = ToolBox.tools_to_openai_spec([
+            {"name": "add", "description": "Add two ints.",
+             "argument_schema": {"type": "object", "properties": {"a": {"type": "integer"}}},
+             "output_schema": {}},
+        ])
+        self.assertEqual(spec[0]["type"], "function")
+        fn = spec[0]["function"]
+        self.assertEqual(fn["name"], "add")
+        self.assertEqual(fn["description"], "Add two ints.")
+        # parameters is exactly the argument_schema
+        self.assertEqual(fn["parameters"]["properties"]["a"]["type"], "integer")
+
+    def test_missing_description_and_schema_defaults(self):
+        spec = ToolBox.tools_to_openai_spec([{"name": "noop"}])
+        self.assertEqual(spec[0]["function"]["description"], "")
+        self.assertEqual(spec[0]["function"]["parameters"],
+                         {"type": "object", "properties": {}})
+
+    def test_openai_tools_property(self):
+        tb = MathToolBox()
+        spec = tb.openai_tools
+        self.assertEqual(spec[0]["function"]["name"], "add")
+        self.assertEqual(spec, ToolBox.tools_to_openai_spec(tb.tool_json_list))
+
+
 class TestToolBoxBusHandlers(unittest.TestCase):
     def setUp(self):
         self.bus = FakeBus()

--- a/test/unittests/test_agents.py
+++ b/test/unittests/test_agents.py
@@ -36,6 +36,7 @@ from ovos_plugin_manager.templates.agents import (
     ReRankerEngine,
     RetrievalEngine,
     SummarizerEngine,
+    ToolCall,
     YesNoEngine,
 )
 from ovos_plugin_manager.utils import PluginTypes
@@ -81,6 +82,27 @@ class _ChatEngineImpl(ChatEngine):
         """Echo the last user message back."""
         last = messages[-1].content if messages else "hello"
         return AgentMessage(role=MessageRole.ASSISTANT, content=f"echo: {last}")
+
+
+class _ToolChatEngineImpl(ChatEngine):
+    """Minimal tool-aware ChatEngine that echoes back the tools it received."""
+
+    supports_tools = True
+
+    def continue_chat(
+        self,
+        messages: List[AgentMessage],
+        session_id: str = "default",
+        lang: Optional[str] = None,
+        units: Optional[str] = None,
+        tools: Optional[List[Dict]] = None,
+    ) -> AgentMessage:
+        """Return a tool_call when tools are offered, else a plain answer."""
+        if tools:
+            name = tools[0]["function"]["name"]
+            return AgentMessage(role=MessageRole.ASSISTANT, content="",
+                                tool_calls=[ToolCall(id="c1", name=name, arguments={"x": 1})])
+        return AgentMessage(role=MessageRole.ASSISTANT, content="no tools")
 
 
 class _MultimodalChatEngineImpl(MultimodalChatEngine):
@@ -151,6 +173,58 @@ class TestAgentMessage(unittest.TestCase):
         self.assertEqual(msg.audio_content, [])
         self.assertEqual(msg.file_content, [])
 
+    def test_tool_role_exists(self) -> None:
+        """MessageRole.TOOL is available and wire-serializes to 'tool'."""
+        self.assertEqual(MessageRole.TOOL.value, "tool")
+        self.assertIn("tool", {r.value for r in MessageRole})
+
+    def test_tool_fields_default_none(self) -> None:
+        """New tool fields default to None (backward compatible construction)."""
+        msg = AgentMessage(role=MessageRole.USER, content="hi")
+        self.assertIsNone(msg.tool_calls)
+        self.assertIsNone(msg.tool_call_id)
+        self.assertIsNone(msg.name)
+
+    def test_assistant_with_tool_calls(self) -> None:
+        """An assistant message can carry tool_calls; content may be empty."""
+        msg = AgentMessage(role=MessageRole.ASSISTANT, content="",
+                           tool_calls=[ToolCall(id="c1", name="calc", arguments={"a": 2})])
+        self.assertEqual(msg.tool_calls[0].name, "calc")
+        self.assertEqual(msg.tool_calls[0].arguments, {"a": 2})
+
+    def test_tool_result_message(self) -> None:
+        """A TOOL message references the ToolCall it answers."""
+        msg = AgentMessage(role=MessageRole.TOOL, content="4",
+                           tool_call_id="c1", name="calc")
+        self.assertEqual(msg.role, MessageRole.TOOL)
+        self.assertEqual(msg.tool_call_id, "c1")
+
+    def test_multimodal_inherits_tool_fields(self) -> None:
+        """MultimodalAgentMessage inherits the tool fields, defaulting None."""
+        msg = MultimodalAgentMessage(role=MessageRole.ASSISTANT, content="")
+        self.assertIsNone(msg.tool_calls)
+        self.assertIsNone(msg.tool_call_id)
+
+
+class TestToolCall(unittest.TestCase):
+    """Tests for the ToolCall dataclass."""
+
+    def test_fields(self) -> None:
+        tc = ToolCall(id="c1", name="calc", arguments={"a": 1, "b": 2})
+        self.assertEqual((tc.id, tc.name), ("c1", "calc"))
+        self.assertEqual(tc.arguments, {"a": 1, "b": 2})
+
+    def test_arguments_default_empty(self) -> None:
+        tc = ToolCall(id="c1", name="calc")
+        self.assertEqual(tc.arguments, {})
+
+    def test_asdict_roundtrip(self) -> None:
+        from dataclasses import asdict
+        tc = ToolCall(id="c1", name="calc", arguments={"a": 1})
+        d = asdict(tc)
+        self.assertEqual(d, {"id": "c1", "name": "calc", "arguments": {"a": 1}})
+        self.assertEqual(ToolCall(**d), tc)
+
 
 # ---------------------------------------------------------------------------
 # Tests for AgentContextManager
@@ -210,6 +284,29 @@ class TestChatEngine(unittest.TestCase):
         result = self.engine.continue_chat(msgs)
         self.assertIsInstance(result, AgentMessage)
         self.assertIn("ping", result.content)
+
+    def test_supports_tools_default_false(self) -> None:
+        """A plain ChatEngine advertises no tool support."""
+        self.assertFalse(self.engine.supports_tools)
+        self.assertFalse(ChatEngine.supports_tools)
+
+    def test_legacy_signature_still_satisfies_abc(self) -> None:
+        """An engine defining the pre-tools 4-arg continue_chat is still concrete."""
+        # _ChatEngineImpl omits the `tools` kwarg entirely — must still work.
+        msgs = [AgentMessage(role=MessageRole.USER, content="x")]
+        self.assertIsInstance(self.engine.continue_chat(msgs), AgentMessage)
+
+    def test_tool_aware_engine_accepts_tools(self) -> None:
+        """A tool-aware engine accepts the tools= kwarg and returns tool_calls."""
+        engine = _ToolChatEngineImpl()
+        self.assertTrue(engine.supports_tools)
+        specs = [{"type": "function", "function": {"name": "calc", "parameters": {}}}]
+        out = engine.continue_chat([AgentMessage(role=MessageRole.USER, content="2?")],
+                                   tools=specs)
+        self.assertEqual(out.tool_calls[0].name, "calc")
+        # without tools it falls back to a plain answer
+        out2 = engine.continue_chat([AgentMessage(role=MessageRole.USER, content="hi")])
+        self.assertIsNone(out2.tool_calls)
 
     def test_get_response(self) -> None:
         """get_response returns plain string."""


### PR DESCRIPTION
Makes tool turns representable *in a conversation* so a tool loop can be threaded through chat history, persisted by memory/context plugins, and use providers' native function-calling. OVOS already has the tool abstractions (`AgentTool`/`ToolBox`, `tool_json_list`, bus + MCP/UTCP execution) but no way to carry a tool turn in `AgentMessage`.

## Changes (additive, backward-compatible)
- `MessageRole.TOOL` + a `ToolCall` dataclass (`id`, `name`, `arguments`).
- `AgentMessage` gains optional trailing `tool_calls` / `tool_call_id` / `name` (default `None`; `MultimodalAgentMessage` inherits them).
- `ChatEngine.supports_tools` class flag (default `False`) and an optional trailing `tools=` kwarg on `continue_chat` — existing 4-arg overrides keep satisfying the ABC, so released plugins are unaffected.
- `ToolBox.tools_to_openai_spec` staticmethod + `openai_tools` property: convert `tool_json_list` → the neutral OpenAI `tools`/function spec.

The orchestration loop that consumes this lives in `ovos-agentic-loop` (`NativeToolCallEngine`), not in provider engines.

Tests + docs (`docs/agents.md`, `docs/api/agent-tools.md`) included; 92 agent tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool/function calling support to chat engines with OpenAI-compatible specification format.
  * Engines can now declare tool support and return tool invocations in assistant responses.

* **Documentation**
  * Updated agent and tool documentation to clarify tool calling workflows and message role contracts.

* **Tests**
  * Added comprehensive test coverage for tool specification conversion and tool call handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->