### PR TITLE
refactor!: drop the enclosure abstraction from PHALPlugin

### DIFF
--- a/ovos_plugin_manager/templates/phal.py
+++ b/ovos_plugin_manager/templates/phal.py
@@ -25,14 +25,15 @@ class PHALValidator:
 
 class PHALPlugin(Thread):
     """
-    This base class is intended to be used to build PHAL plugins, which run
-    inside the ``ovos-PHAL`` service and react to lifecycle bus events
-    (audio in/out, wake, sleep, speak).
-    All of the handlers are optional and for convenience only.
+    Base class for PHAL plugins, which run inside the ``ovos-PHAL`` service.
 
-    The legacy Mark-1 ``enclosure.*`` hardware protocol is no longer wired
-    here. Hardware enclosure plugins mix in ``EnclosureProtocolListener`` from
-    ``ovos-ui-enclosure-protocol`` instead.
+    A PHAL plugin is a background ``Thread`` with access to the message bus
+    (``self.bus``); subclasses wire their own bus handlers and override
+    :meth:`run` for any main loop.
+
+    This base does not wire any bus events. Hardware enclosure plugins mix in
+    ``EnclosureProtocolListener`` from ``ovos-ui-enclosure-protocol`` for the
+    ``enclosure.*`` commands and the record/speak/wake/sleep lifecycle.
     """
     validator = PHALValidator
 
@@ -45,19 +46,7 @@ class PHALPlugin(Thread):
         self.bus = bus or get_mycroft_bus()
         self.log = LOG
         self.name = name
-
-        self.register_core_events()
         self.start()
-
-    def register_core_events(self):
-        # audio events
-        self.bus.on('recognizer_loop:record_begin', self.on_record_begin)
-        self.bus.on('recognizer_loop:record_end', self.on_record_end)
-        self.bus.on("recognizer_loop:sleep", self.on_sleep)
-        self.bus.on('recognizer_loop:audio_output_start', self.on_audio_output_start)
-        self.bus.on('recognizer_loop:audio_output_end', self.on_audio_output_end)
-        self.bus.on("mycroft.awoken", self.on_awake)
-        self.bus.on("speak", self.on_speak)
 
     @classproperty
     def runtime_requirements(cls):
@@ -89,50 +78,12 @@ class PHALPlugin(Thread):
         self.bus.emit(Message(f"{skill_id}.{msg_type}", msg_data, {"skill_id": skill_id}))
 
     def shutdown(self):
-        self.bus.remove("mycroft.awoken", self.on_awake)
-        self.bus.remove("recognizer_loop:sleep", self.on_sleep)
-        self.bus.remove("speak", self.on_speak)
-        self.bus.remove('recognizer_loop:record_begin', self.on_record_begin)
-        self.bus.remove('recognizer_loop:record_end', self.on_record_end)
-        self.bus.remove('recognizer_loop:audio_output_start', self.on_audio_output_start)
-        self.bus.remove('recognizer_loop:audio_output_end', self.on_audio_output_end)
-
         self._running = False
 
     def run(self):
         ''' plugin main loop, override if needed '''
         pass
 
-    # Audio Events
-    def on_record_begin(self, message=None):
-        ''' listening started '''
-        pass
-
-    def on_record_end(self, message=None):
-        ''' listening ended '''
-        pass
-
-    def on_audio_output_start(self, message=None):
-        ''' speaking started '''
-        pass
-
-    def on_audio_output_end(self, message=None):
-        ''' speaking started '''
-        pass
-
-    def on_awake(self, message=None):
-        ''' on wakeup animation '''
-        pass
-
-    def on_sleep(self, message=None):
-        ''' on naptime animation '''
-        # TODO naptime skill animation should be ond here
-        pass
-
-    def on_speak(self, message=None):
-        ''' on speak messages, intended for enclosures that disregard
-        visemes '''
-        pass
 
 class AdminPlugin(PHALPlugin):
     """Running as Admin"""

--- a/ovos_plugin_manager/templates/phal.py
+++ b/ovos_plugin_manager/templates/phal.py
@@ -25,10 +25,14 @@ class PHALValidator:
 
 class PHALPlugin(Thread):
     """
-    This base class is intended to be used to interface with the hardware
-    that is running OpenVoiceOS.  It exposes all possible commands which
-    are expected be sent to a PHAL plugin.
-    All of the handlers are optional and for convenience only
+    This base class is intended to be used to build PHAL plugins, which run
+    inside the ``ovos-PHAL`` service and react to lifecycle bus events
+    (audio in/out, wake, sleep, speak).
+    All of the handlers are optional and for convenience only.
+
+    The legacy Mark-1 ``enclosure.*`` hardware protocol is no longer wired
+    here. Hardware enclosure plugins mix in ``EnclosureProtocolListener`` from
+    ``ovos-ui-enclosure-protocol`` instead.
     """
     validator = PHALValidator
 
@@ -37,16 +41,12 @@ class PHALPlugin(Thread):
         self.config_core = Configuration()
         name = name or camel_case_split(self.__class__.__name__).replace(" ", "-").lower()
         self.config = config or self.config_core.get("PHAL", {}).get(name, {})
-        self._mouth_events = False
         self._running = False
         self.bus = bus or get_mycroft_bus()
         self.log = LOG
         self.name = name
 
-        self.register_enclosure_namespace()
         self.register_core_events()
-
-        self._activate_mouth_events()
         self.start()
 
     def register_core_events(self):
@@ -58,48 +58,6 @@ class PHALPlugin(Thread):
         self.bus.on('recognizer_loop:audio_output_end', self.on_audio_output_end)
         self.bus.on("mycroft.awoken", self.on_awake)
         self.bus.on("speak", self.on_speak)
-
-    def register_enclosure_namespace(self):
-        self.bus.on("enclosure.notify.no_internet", self.on_no_internet)
-        self.bus.on("enclosure.reset", self.on_reset)
-
-        # enclosure commands for OpenVoiceOS's Hardware.
-        self.bus.on("enclosure.system.reset", self.on_system_reset)
-        self.bus.on("enclosure.system.mute", self.on_system_mute)
-        self.bus.on("enclosure.system.unmute", self.on_system_unmute)
-        self.bus.on("enclosure.system.blink", self.on_system_blink)
-
-        # enclosure commands for eyes
-        self.bus.on('enclosure.eyes.on', self.on_eyes_on)
-        self.bus.on('enclosure.eyes.off', self.on_eyes_off)
-        self.bus.on('enclosure.eyes.blink', self.on_eyes_blink)
-        self.bus.on('enclosure.eyes.narrow', self.on_eyes_narrow)
-        self.bus.on('enclosure.eyes.look', self.on_eyes_look)
-        self.bus.on('enclosure.eyes.color', self.on_eyes_color)
-        self.bus.on('enclosure.eyes.level', self.on_eyes_brightness)
-        self.bus.on('enclosure.eyes.volume', self.on_eyes_volume)
-        self.bus.on('enclosure.eyes.spin', self.on_eyes_spin)
-        self.bus.on('enclosure.eyes.timedspin', self.on_eyes_timed_spin)
-        self.bus.on('enclosure.eyes.reset', self.on_eyes_reset)
-        self.bus.on('enclosure.eyes.setpixel', self.on_eyes_set_pixel)
-        self.bus.on('enclosure.eyes.fill', self.on_eyes_fill)
-
-        # enclosure commands for mouth
-        self.bus.on("enclosure.mouth.events.activate", self._activate_mouth_events)
-        self.bus.on("enclosure.mouth.events.deactivate", self._deactivate_mouth_events)
-        self.bus.on("enclosure.mouth.talk", self._on_mouth_talk)
-        self.bus.on("enclosure.mouth.think", self._on_mouth_think)
-        self.bus.on("enclosure.mouth.listen", self._on_mouth_listen)
-        self.bus.on("enclosure.mouth.smile", self._on_mouth_smile)
-        self.bus.on("enclosure.mouth.viseme", self._on_mouth_viseme)
-        self.bus.on("enclosure.mouth.viseme_list", self._on_mouth_viseme_list)
-
-        # mouth/matrix display
-        self.bus.on("enclosure.mouth.reset", self.on_display_reset)
-        self.bus.on("enclosure.mouth.text", self.on_text)
-        self.bus.on("enclosure.mouth.display", self.on_display)
-        self.bus.on("enclosure.weather.display", self.on_weather_display)
-
 
     @classproperty
     def runtime_requirements(cls):
@@ -131,53 +89,18 @@ class PHALPlugin(Thread):
         self.bus.emit(Message(f"{skill_id}.{msg_type}", msg_data, {"skill_id": skill_id}))
 
     def shutdown(self):
-        self.bus.remove("enclosure.reset", self.on_reset)
-        self.bus.remove("enclosure.system.reset", self.on_system_reset)
-        self.bus.remove("enclosure.system.mute", self.on_system_mute)
-        self.bus.remove("enclosure.system.unmute", self.on_system_unmute)
-        self.bus.remove("enclosure.system.blink", self.on_system_blink)
-
-        self.bus.remove("enclosure.eyes.on", self.on_eyes_on)
-        self.bus.remove("enclosure.eyes.off", self.on_eyes_off)
-        self.bus.remove("enclosure.eyes.blink", self.on_eyes_blink)
-        self.bus.remove("enclosure.eyes.narrow", self.on_eyes_narrow)
-        self.bus.remove("enclosure.eyes.look", self.on_eyes_look)
-        self.bus.remove("enclosure.eyes.color", self.on_eyes_color)
-        self.bus.remove("enclosure.eyes.brightness", self.on_eyes_brightness)
-        self.bus.remove("enclosure.eyes.reset", self.on_eyes_reset)
-        self.bus.remove("enclosure.eyes.timedspin", self.on_eyes_timed_spin)
-        self.bus.remove("enclosure.eyes.volume", self.on_eyes_volume)
-        self.bus.remove("enclosure.eyes.spin", self.on_eyes_spin)
-        self.bus.remove("enclosure.eyes.setpixel", self.on_eyes_set_pixel)
-        self.bus.remove('enclosure.eyes.fill', self.on_eyes_fill)
-
-        self.bus.remove("enclosure.mouth.reset", self.on_display_reset)
-        self.bus.remove("enclosure.mouth.talk", self.on_talk)
-        self.bus.remove("enclosure.mouth.think", self.on_think)
-        self.bus.remove("enclosure.mouth.listen", self.on_listen)
-        self.bus.remove("enclosure.mouth.smile", self.on_smile)
-        self.bus.remove("enclosure.mouth.viseme", self.on_viseme)
-        self.bus.remove("enclosure.mouth.viseme_list", self._on_mouth_viseme_list)
-        self.bus.remove("enclosure.mouth.text", self.on_text)
-        self.bus.remove("enclosure.mouth.display", self.on_display)
-        self.bus.remove("enclosure.mouth.events.activate", self._activate_mouth_events)
-        self.bus.remove("enclosure.mouth.events.deactivate", self._deactivate_mouth_events)
-
-        self.bus.remove("enclosure.weather.display", self.on_weather_display)
-
         self.bus.remove("mycroft.awoken", self.on_awake)
         self.bus.remove("recognizer_loop:sleep", self.on_sleep)
         self.bus.remove("speak", self.on_speak)
         self.bus.remove('recognizer_loop:record_begin', self.on_record_begin)
         self.bus.remove('recognizer_loop:record_end', self.on_record_end)
         self.bus.remove('recognizer_loop:audio_output_start', self.on_audio_output_start)
-        self.bus.remove("enclosure.notify.no_internet", self.on_no_internet)
+        self.bus.remove('recognizer_loop:audio_output_end', self.on_audio_output_end)
 
-        self._deactivate_mouth_events()
         self._running = False
 
     def run(self):
-        ''' start enclosure '''
+        ''' plugin main loop, override if needed '''
         pass
 
     # Audio Events
@@ -210,297 +133,6 @@ class PHALPlugin(Thread):
         ''' on speak messages, intended for enclosures that disregard
         visemes '''
         pass
-
-    def on_reset(self, message=None):
-        """The enclosure should restore itself to a started state.
-        Typically this would be represented by the eyes being 'open'
-        and the mouth reset to its default (smile or blank).
-        """
-        pass
-
-    # System Events
-    def on_no_internet(self, message=None):
-        """
-
-        Args:
-            message:
-        """
-        pass
-
-    def on_system_reset(self, message=None):
-        """The enclosure hardware should reset any CPUs, etc."""
-        pass
-
-    def on_system_mute(self, message=None):
-        """Mute (turn off) the system speaker."""
-        pass
-
-    def on_system_unmute(self, message=None):
-        """Unmute (turn on) the system speaker."""
-        pass
-
-    def on_system_blink(self, message=None):
-        """The 'eyes' should blink the given number of times.
-        Args:
-            times (int): number of times to blink
-        """
-        pass
-
-    # Eyes events
-    def on_eyes_on(self, message=None):
-        """Illuminate or show the eyes."""
-        pass
-
-    def on_eyes_off(self, message=None):
-        """Turn off or hide the eyes."""
-        pass
-
-    def on_eyes_fill(self, message=None):
-        pass
-
-    def on_eyes_blink(self, message=None):
-        """Make the eyes blink
-        Args:
-            side (str): 'r', 'l', or 'b' for 'right', 'left' or 'both'
-        """
-        pass
-
-    def on_eyes_narrow(self, message=None):
-        """Make the eyes look narrow, like a squint"""
-        pass
-
-    def on_eyes_look(self, message=None):
-        """Make the eyes look to the given side
-        Args:
-            side (str): 'r' for right
-                        'l' for left
-                        'u' for up
-                        'd' for down
-                        'c' for crossed
-        """
-        pass
-
-    def on_eyes_color(self, message=None):
-        """Change the eye color to the given RGB color
-        Args:
-            r (int): 0-255, red value
-            g (int): 0-255, green value
-            b (int): 0-255, blue value
-        """
-        pass
-
-    def on_eyes_brightness(self, message=None):
-        """Set the brightness of the eyes in the display.
-        Args:
-            level (int): 1-30, bigger numbers being brighter
-        """
-        pass
-
-    def on_eyes_reset(self, message=None):
-        """Restore the eyes to their default (ready) state."""
-        pass
-
-    def on_eyes_timed_spin(self, message=None):
-        """Make the eyes 'roll' for the given time.
-        Args:
-            length (int): duration in milliseconds of roll, None = forever
-        """
-        pass
-
-    def on_eyes_volume(self, message=None):
-        """Indicate the volume using the eyes
-        Args:
-            volume (int): 0 to 11
-        """
-        pass
-
-    def on_eyes_spin(self, message=None):
-        """
-        Args:
-        """
-        pass
-
-    def on_eyes_set_pixel(self, message=None):
-        """
-        Args:
-        """
-        pass
-
-    # Mouth events
-    def _on_mouth_reset(self, message=None):
-        """Restore the mouth display to normal (blank)"""
-        if self.mouth_events_active:
-            self.on_display_reset(message)
-
-    def _on_mouth_talk(self, message=None):
-        """Show a generic 'talking' animation for non-synched speech"""
-        if self.mouth_events_active:
-            self.on_talk(message)
-
-    def _on_mouth_think(self, message=None):
-        """Show a 'thinking' image or animation"""
-        if self.mouth_events_active:
-            self.on_think(message)
-
-    def _on_mouth_listen(self, message=None):
-        """Show a 'thinking' image or animation"""
-        if self.mouth_events_active:
-            self.on_listen(message)
-
-    def _on_mouth_smile(self, message=None):
-        """Show a 'smile' image or animation"""
-        if self.mouth_events_active:
-            self.on_smile(message)
-
-    def _on_mouth_viseme(self, message=None):
-        """Display a viseme mouth shape for synched speech
-        Args:
-            code (int):  0 = shape for sounds like 'y' or 'aa'
-                         1 = shape for sounds like 'aw'
-                         2 = shape for sounds like 'uh' or 'r'
-                         3 = shape for sounds like 'th' or 'sh'
-                         4 = neutral shape for no sound
-                         5 = shape for sounds like 'f' or 'v'
-                         6 = shape for sounds like 'oy' or 'ao'
-        """
-        if self.mouth_events_active:
-            self.on_viseme(message)
-
-    def _on_mouth_viseme_list(self, message=None):
-        """mouth visemes as a list in a single message.
-
-            Args:
-                start (int):    Timestamp for start of speech
-                viseme_pairs:   Pairs of viseme id and cumulative end times
-                                (code, end time)
-
-                                codes:
-                                 0 = shape for sounds like 'y' or 'aa'
-                                 1 = shape for sounds like 'aw'
-                                 2 = shape for sounds like 'uh' or 'r'
-                                 3 = shape for sounds like 'th' or 'sh'
-                                 4 = neutral shape for no sound
-                                 5 = shape for sounds like 'f' or 'v'
-                                 6 = shape for sounds like 'oy' or 'ao'
-        """
-        if self.mouth_events_active:
-            self.on_viseme_list(message)
-
-    def _on_mouth_text(self, message=None):
-        """Display text (scrolling as needed)
-        Args:
-            text (str): text string to display
-        """
-        if self.mouth_events_active:
-            self.on_text(message)
-
-    def _on_mouth_display(self, message=None):
-        if self.mouth_events_active:
-            self.on_display(message)
-
-    # Display (faceplate) events
-    def on_display_reset(self, message=None):
-        """Restore the mouth display to normal (blank)"""
-        pass
-
-    def on_talk(self, message=None):
-        """Show a generic 'talking' animation for non-synched speech"""
-        pass
-
-    def on_think(self, message=None):
-        """Show a 'thinking' image or animation"""
-        pass
-
-    def on_listen(self, message=None):
-        """Show a 'thinking' image or animation"""
-        pass
-
-    def on_smile(self, message=None):
-        """Show a 'smile' image or animation"""
-        pass
-
-    def on_viseme(self, message=None):
-        """Display a viseme mouth shape for synched speech
-        Args:
-            code (int):  0 = shape for sounds like 'y' or 'aa'
-                         1 = shape for sounds like 'aw'
-                         2 = shape for sounds like 'uh' or 'r'
-                         3 = shape for sounds like 'th' or 'sh'
-                         4 = neutral shape for no sound
-                         5 = shape for sounds like 'f' or 'v'
-                         6 = shape for sounds like 'oy' or 'ao'
-        """
-        pass
-
-    def on_viseme_list(self, message=None):
-        """ Send mouth visemes as a list in a single message.
-
-            Args:
-                start (int):    Timestamp for start of speech
-                viseme_pairs:   Pairs of viseme id and cumulative end times
-                                (code, end time)
-
-                                codes:
-                                 0 = shape for sounds like 'y' or 'aa'
-                                 1 = shape for sounds like 'aw'
-                                 2 = shape for sounds like 'uh' or 'r'
-                                 3 = shape for sounds like 'th' or 'sh'
-                                 4 = neutral shape for no sound
-                                 5 = shape for sounds like 'f' or 'v'
-                                 6 = shape for sounds like 'oy' or 'ao'
-        """
-        pass
-
-    def on_text(self, message=None):
-        """Display text (scrolling as needed)
-        Args:
-            text (str): text string to display
-        """
-        pass
-
-    def on_display(self, message=None):
-        """Display images on faceplate. Currently supports images up to 16x8,
-           or half the face. You can use the 'x' parameter to cover the other
-           half of the faceplate.
-        Args:
-            img_code (str): text string that encodes a black and white image
-            x (int): x offset for image
-            y (int): y offset for image
-            refresh (bool): specify whether to clear the faceplate before
-                            displaying the new image or not.
-                            Useful if you'd like to display muliple images
-                            on the faceplate at once.
-        """
-        pass
-
-    def on_weather_display(self, message=None):
-        """Show a the temperature and a weather icon
-
-        Args:
-            img_code (char): one of the following icon codes
-                         0 = sunny
-                         1 = partly cloudy
-                         2 = cloudy
-                         3 = light rain
-                         4 = raining
-                         5 = stormy
-                         6 = snowing
-                         7 = wind/mist
-            temp (int): the temperature (either C or F, not indicated)
-        """
-        pass
-
-    @property
-    def mouth_events_active(self):
-        return self._mouth_events
-
-    def _activate_mouth_events(self, message=None):
-        """Enable movement of the mouth with speech"""
-        self._mouth_events = True
-
-    def _deactivate_mouth_events(self, message=None):
-        """Disable movement of the mouth with speech"""
-        self._mouth_events = False
 
 class AdminPlugin(PHALPlugin):
     """Running as Admin"""

--- a/test/unittests/test_phal_template_extended.py
+++ b/test/unittests/test_phal_template_extended.py
@@ -52,101 +52,43 @@ class TestPHALPluginRuntimeRequirements(unittest.TestCase):
         self.assertTrue(reqs.no_network_fallback)
 
 
-class TestPHALPluginCoreEvents(unittest.TestCase):
-    """Tests for the core lifecycle bus subscriptions wired on init."""
+class TestPHALPluginIsBareBase(unittest.TestCase):
+    """The base wires no bus events and carries no enclosure/lifecycle handlers."""
 
-    def test_register_core_events_subscribes(self) -> None:
-        """register_core_events wires the audio/wake/speak lifecycle events."""
+    def test_no_bus_subscriptions_on_init(self) -> None:
+        """The base plugin does not wire any bus events on construction."""
         plugin = _make_plugin()
-        wired = {call.args[0] for call in plugin.bus.on.call_args_list}
-        self.assertEqual(wired, {
-            "recognizer_loop:record_begin",
-            "recognizer_loop:record_end",
-            "recognizer_loop:sleep",
-            "recognizer_loop:audio_output_start",
-            "recognizer_loop:audio_output_end",
-            "mycroft.awoken",
-            "speak",
-        })
-
-    def test_no_enclosure_namespace_wired(self) -> None:
-        """No enclosure.* subscriptions are wired by the base plugin."""
-        plugin = _make_plugin()
-        wired = {call.args[0] for call in plugin.bus.on.call_args_list}
-        self.assertFalse(any(t.startswith("enclosure.") for t in wired))
+        self.assertEqual(plugin.bus.on.call_args_list, [])
 
     def test_no_enclosure_abstraction_attributes(self) -> None:
         """The dropped enclosure abstraction leaves no attributes behind."""
         plugin = _make_plugin()
         self.assertFalse(hasattr(plugin, "register_enclosure_namespace"))
+        self.assertFalse(hasattr(plugin, "register_core_events"))
         self.assertFalse(hasattr(plugin, "mouth_events_active"))
         self.assertFalse(hasattr(plugin, "on_eyes_on"))
         self.assertFalse(hasattr(plugin, "on_weather_display"))
 
-
-class TestPHALPluginEventHandlers(unittest.TestCase):
-    """Tests for PHALPlugin stub event handler methods (all are no-ops by default)."""
-
-    def setUp(self) -> None:
-        """Create a plugin instance."""
-        self.plugin: PHALPlugin = _make_plugin()
-
-    def test_on_record_begin(self) -> None:
-        """on_record_begin does not raise."""
-        self.plugin.on_record_begin()
-
-    def test_on_record_end(self) -> None:
-        """on_record_end does not raise."""
-        self.plugin.on_record_end()
-
-    def test_on_audio_output_start(self) -> None:
-        """on_audio_output_start does not raise."""
-        self.plugin.on_audio_output_start()
-
-    def test_on_audio_output_end(self) -> None:
-        """on_audio_output_end does not raise."""
-        self.plugin.on_audio_output_end()
-
-    def test_on_awake(self) -> None:
-        """on_awake does not raise."""
-        self.plugin.on_awake()
-
-    def test_on_sleep(self) -> None:
-        """on_sleep does not raise."""
-        self.plugin.on_sleep()
-
-    def test_on_speak(self) -> None:
-        """on_speak does not raise."""
-        self.plugin.on_speak()
-
-    def test_run(self) -> None:
-        """run does not raise."""
-        self.plugin.run()
+    def test_no_lifecycle_handlers(self) -> None:
+        """The record/speak/wake/sleep handlers moved to the listener mix-in."""
+        plugin = _make_plugin()
+        for name in ("on_record_begin", "on_record_end", "on_audio_output_start",
+                     "on_audio_output_end", "on_awake", "on_sleep", "on_speak"):
+            self.assertFalse(hasattr(plugin, name), name)
 
 
-class TestPHALPluginShutdown(unittest.TestCase):
-    """Tests for PHALPlugin.shutdown."""
+class TestPHALPluginLifecycle(unittest.TestCase):
+    """Tests for the bare plugin lifecycle (run/shutdown)."""
+
+    def test_run_does_not_raise(self) -> None:
+        _make_plugin().run()
 
     def test_shutdown_sets_running_false(self) -> None:
-        """shutdown sets _running to False."""
+        """shutdown sets _running to False without touching the bus."""
         plugin = _make_plugin()
         plugin.shutdown()
         self.assertFalse(plugin._running)
-
-    def test_shutdown_removes_core_events(self) -> None:
-        """shutdown removes the core lifecycle subscriptions."""
-        plugin = _make_plugin()
-        plugin.shutdown()
-        removed = {call.args[0] for call in plugin.bus.remove.call_args_list}
-        self.assertEqual(removed, {
-            "mycroft.awoken",
-            "recognizer_loop:sleep",
-            "speak",
-            "recognizer_loop:record_begin",
-            "recognizer_loop:record_end",
-            "recognizer_loop:audio_output_start",
-            "recognizer_loop:audio_output_end",
-        })
+        self.assertEqual(plugin.bus.remove.call_args_list, [])
 
 
 class TestAdminPluginExtended(unittest.TestCase):

--- a/test/unittests/test_phal_template_extended.py
+++ b/test/unittests/test_phal_template_extended.py
@@ -52,133 +52,36 @@ class TestPHALPluginRuntimeRequirements(unittest.TestCase):
         self.assertTrue(reqs.no_network_fallback)
 
 
-class TestPHALPluginMouthEvents(unittest.TestCase):
-    """Tests for mouth event activation, deactivation, and delegate methods."""
+class TestPHALPluginCoreEvents(unittest.TestCase):
+    """Tests for the core lifecycle bus subscriptions wired on init."""
 
-    def setUp(self) -> None:
-        """Create a plugin instance."""
-        self.plugin: PHALPlugin = _make_plugin()
+    def test_register_core_events_subscribes(self) -> None:
+        """register_core_events wires the audio/wake/speak lifecycle events."""
+        plugin = _make_plugin()
+        wired = {call.args[0] for call in plugin.bus.on.call_args_list}
+        self.assertEqual(wired, {
+            "recognizer_loop:record_begin",
+            "recognizer_loop:record_end",
+            "recognizer_loop:sleep",
+            "recognizer_loop:audio_output_start",
+            "recognizer_loop:audio_output_end",
+            "mycroft.awoken",
+            "speak",
+        })
 
-    def test_mouth_events_initially_true(self) -> None:
-        """mouth_events_active is True after _activate_mouth_events called during init."""
-        self.assertTrue(self.plugin.mouth_events_active)
+    def test_no_enclosure_namespace_wired(self) -> None:
+        """No enclosure.* subscriptions are wired by the base plugin."""
+        plugin = _make_plugin()
+        wired = {call.args[0] for call in plugin.bus.on.call_args_list}
+        self.assertFalse(any(t.startswith("enclosure.") for t in wired))
 
-    def test_deactivate_mouth_events(self) -> None:
-        """_deactivate_mouth_events sets mouth_events_active to False."""
-        self.plugin._deactivate_mouth_events()
-        self.assertFalse(self.plugin.mouth_events_active)
-
-    def test_activate_mouth_events(self) -> None:
-        """_activate_mouth_events sets mouth_events_active to True."""
-        self.plugin._deactivate_mouth_events()
-        self.plugin._activate_mouth_events()
-        self.assertTrue(self.plugin.mouth_events_active)
-
-    def _activate(self) -> None:
-        """Helper: ensure mouth events are active."""
-        self.plugin._activate_mouth_events()
-
-    def _deactivate(self) -> None:
-        """Helper: ensure mouth events are inactive."""
-        self.plugin._deactivate_mouth_events()
-
-    def test_on_mouth_talk_active(self) -> None:
-        """_on_mouth_talk delegates to on_talk when active."""
-        self._activate()
-        self.plugin.on_talk = MagicMock()
-        self.plugin._on_mouth_talk(MagicMock())
-        self.plugin.on_talk.assert_called_once()
-
-    def test_on_mouth_talk_inactive(self) -> None:
-        """_on_mouth_talk does not delegate when inactive."""
-        self._deactivate()
-        self.plugin.on_talk = MagicMock()
-        self.plugin._on_mouth_talk(MagicMock())
-        self.plugin.on_talk.assert_not_called()
-
-    def test_on_mouth_think_active(self) -> None:
-        """_on_mouth_think delegates to on_think when active."""
-        self._activate()
-        self.plugin.on_think = MagicMock()
-        self.plugin._on_mouth_think(MagicMock())
-        self.plugin.on_think.assert_called_once()
-
-    def test_on_mouth_think_inactive(self) -> None:
-        """_on_mouth_think does not delegate when inactive."""
-        self._deactivate()
-        self.plugin.on_think = MagicMock()
-        self.plugin._on_mouth_think(MagicMock())
-        self.plugin.on_think.assert_not_called()
-
-    def test_on_mouth_listen_active(self) -> None:
-        """_on_mouth_listen delegates to on_listen when active."""
-        self._activate()
-        self.plugin.on_listen = MagicMock()
-        self.plugin._on_mouth_listen(MagicMock())
-        self.plugin.on_listen.assert_called_once()
-
-    def test_on_mouth_listen_inactive(self) -> None:
-        """_on_mouth_listen does not delegate when inactive."""
-        self._deactivate()
-        self.plugin.on_listen = MagicMock()
-        self.plugin._on_mouth_listen(MagicMock())
-        self.plugin.on_listen.assert_not_called()
-
-    def test_on_mouth_smile_active(self) -> None:
-        """_on_mouth_smile delegates to on_smile when active."""
-        self._activate()
-        self.plugin.on_smile = MagicMock()
-        self.plugin._on_mouth_smile(MagicMock())
-        self.plugin.on_smile.assert_called_once()
-
-    def test_on_mouth_smile_inactive(self) -> None:
-        """_on_mouth_smile does not delegate when inactive."""
-        self._deactivate()
-        self.plugin.on_smile = MagicMock()
-        self.plugin._on_mouth_smile(MagicMock())
-        self.plugin.on_smile.assert_not_called()
-
-    def test_on_mouth_viseme_active(self) -> None:
-        """_on_mouth_viseme delegates to on_viseme when active."""
-        self._activate()
-        self.plugin.on_viseme = MagicMock()
-        self.plugin._on_mouth_viseme(MagicMock())
-        self.plugin.on_viseme.assert_called_once()
-
-    def test_on_mouth_viseme_inactive(self) -> None:
-        """_on_mouth_viseme does not delegate when inactive."""
-        self._deactivate()
-        self.plugin.on_viseme = MagicMock()
-        self.plugin._on_mouth_viseme(MagicMock())
-        self.plugin.on_viseme.assert_not_called()
-
-    def test_on_mouth_viseme_list_active(self) -> None:
-        """_on_mouth_viseme_list delegates to on_viseme_list when active."""
-        self._activate()
-        self.plugin.on_viseme_list = MagicMock()
-        self.plugin._on_mouth_viseme_list(MagicMock())
-        self.plugin.on_viseme_list.assert_called_once()
-
-    def test_on_mouth_viseme_list_inactive(self) -> None:
-        """_on_mouth_viseme_list does not delegate when inactive."""
-        self._deactivate()
-        self.plugin.on_viseme_list = MagicMock()
-        self.plugin._on_mouth_viseme_list(MagicMock())
-        self.plugin.on_viseme_list.assert_not_called()
-
-    def test_on_mouth_reset_active(self) -> None:
-        """_on_mouth_reset delegates to on_display_reset when active."""
-        self._activate()
-        self.plugin.on_display_reset = MagicMock()
-        self.plugin._on_mouth_reset(MagicMock())
-        self.plugin.on_display_reset.assert_called_once()
-
-    def test_on_mouth_reset_inactive(self) -> None:
-        """_on_mouth_reset does not delegate when inactive."""
-        self._deactivate()
-        self.plugin.on_display_reset = MagicMock()
-        self.plugin._on_mouth_reset(MagicMock())
-        self.plugin.on_display_reset.assert_not_called()
+    def test_no_enclosure_abstraction_attributes(self) -> None:
+        """The dropped enclosure abstraction leaves no attributes behind."""
+        plugin = _make_plugin()
+        self.assertFalse(hasattr(plugin, "register_enclosure_namespace"))
+        self.assertFalse(hasattr(plugin, "mouth_events_active"))
+        self.assertFalse(hasattr(plugin, "on_eyes_on"))
+        self.assertFalse(hasattr(plugin, "on_weather_display"))
 
 
 class TestPHALPluginEventHandlers(unittest.TestCase):
@@ -216,122 +119,6 @@ class TestPHALPluginEventHandlers(unittest.TestCase):
         """on_speak does not raise."""
         self.plugin.on_speak()
 
-    def test_on_reset(self) -> None:
-        """on_reset does not raise."""
-        self.plugin.on_reset()
-
-    def test_on_no_internet(self) -> None:
-        """on_no_internet does not raise."""
-        self.plugin.on_no_internet()
-
-    def test_on_system_reset(self) -> None:
-        """on_system_reset does not raise."""
-        self.plugin.on_system_reset()
-
-    def test_on_system_mute(self) -> None:
-        """on_system_mute does not raise."""
-        self.plugin.on_system_mute()
-
-    def test_on_system_unmute(self) -> None:
-        """on_system_unmute does not raise."""
-        self.plugin.on_system_unmute()
-
-    def test_on_system_blink(self) -> None:
-        """on_system_blink does not raise."""
-        self.plugin.on_system_blink()
-
-    def test_on_eyes_on(self) -> None:
-        """on_eyes_on does not raise."""
-        self.plugin.on_eyes_on()
-
-    def test_on_eyes_off(self) -> None:
-        """on_eyes_off does not raise."""
-        self.plugin.on_eyes_off()
-
-    def test_on_eyes_fill(self) -> None:
-        """on_eyes_fill does not raise."""
-        self.plugin.on_eyes_fill()
-
-    def test_on_eyes_blink(self) -> None:
-        """on_eyes_blink does not raise."""
-        self.plugin.on_eyes_blink()
-
-    def test_on_eyes_narrow(self) -> None:
-        """on_eyes_narrow does not raise."""
-        self.plugin.on_eyes_narrow()
-
-    def test_on_eyes_look(self) -> None:
-        """on_eyes_look does not raise."""
-        self.plugin.on_eyes_look()
-
-    def test_on_eyes_color(self) -> None:
-        """on_eyes_color does not raise."""
-        self.plugin.on_eyes_color()
-
-    def test_on_eyes_brightness(self) -> None:
-        """on_eyes_brightness does not raise."""
-        self.plugin.on_eyes_brightness()
-
-    def test_on_eyes_reset(self) -> None:
-        """on_eyes_reset does not raise."""
-        self.plugin.on_eyes_reset()
-
-    def test_on_eyes_timed_spin(self) -> None:
-        """on_eyes_timed_spin does not raise."""
-        self.plugin.on_eyes_timed_spin()
-
-    def test_on_eyes_volume(self) -> None:
-        """on_eyes_volume does not raise."""
-        self.plugin.on_eyes_volume()
-
-    def test_on_eyes_spin(self) -> None:
-        """on_eyes_spin does not raise."""
-        self.plugin.on_eyes_spin()
-
-    def test_on_eyes_set_pixel(self) -> None:
-        """on_eyes_set_pixel does not raise."""
-        self.plugin.on_eyes_set_pixel()
-
-    def test_on_display_reset(self) -> None:
-        """on_display_reset does not raise."""
-        self.plugin.on_display_reset()
-
-    def test_on_talk(self) -> None:
-        """on_talk does not raise."""
-        self.plugin.on_talk()
-
-    def test_on_think(self) -> None:
-        """on_think does not raise."""
-        self.plugin.on_think()
-
-    def test_on_listen(self) -> None:
-        """on_listen does not raise."""
-        self.plugin.on_listen()
-
-    def test_on_smile(self) -> None:
-        """on_smile does not raise."""
-        self.plugin.on_smile()
-
-    def test_on_viseme(self) -> None:
-        """on_viseme does not raise."""
-        self.plugin.on_viseme()
-
-    def test_on_viseme_list(self) -> None:
-        """on_viseme_list does not raise."""
-        self.plugin.on_viseme_list()
-
-    def test_on_text(self) -> None:
-        """on_text does not raise."""
-        self.plugin.on_text()
-
-    def test_on_display(self) -> None:
-        """on_display does not raise."""
-        self.plugin.on_display()
-
-    def test_on_weather_display(self) -> None:
-        """on_weather_display does not raise."""
-        self.plugin.on_weather_display()
-
     def test_run(self) -> None:
         """run does not raise."""
         self.plugin.run()
@@ -346,11 +133,20 @@ class TestPHALPluginShutdown(unittest.TestCase):
         plugin.shutdown()
         self.assertFalse(plugin._running)
 
-    def test_shutdown_deactivates_mouth_events(self) -> None:
-        """shutdown deactivates mouth events."""
+    def test_shutdown_removes_core_events(self) -> None:
+        """shutdown removes the core lifecycle subscriptions."""
         plugin = _make_plugin()
         plugin.shutdown()
-        self.assertFalse(plugin.mouth_events_active)
+        removed = {call.args[0] for call in plugin.bus.remove.call_args_list}
+        self.assertEqual(removed, {
+            "mycroft.awoken",
+            "recognizer_loop:sleep",
+            "speak",
+            "recognizer_loop:record_begin",
+            "recognizer_loop:record_end",
+            "recognizer_loop:audio_output_start",
+            "recognizer_loop:audio_output_end",
+        })
 
 
 class TestAdminPluginExtended(unittest.TestCase):


### PR DESCRIPTION
Removes the legacy Mark-1 `enclosure.*` protocol from the `PHALPlugin` base as a breaking change.

## What changes
`PHALPlugin` no longer wires `enclosure.*`. Removed:
- `register_enclosure_namespace()` and its `__init__` call
- the `enclosure.*` `bus.remove(...)` calls from `shutdown()`
- every enclosure handler: `on_eyes_*`, `on_system_*`, `_on_mouth_*`, `on_text`/`on_display`/`on_weather_display`, `on_reset`/`on_no_internet`, `on_talk`/`on_think`/`on_listen`/`on_smile`/`on_viseme`/`on_viseme_list`/`on_display_reset`
- the mouth-event gating (`mouth_events_active`, `_activate_mouth_events`, `_deactivate_mouth_events`, `_mouth_events`)

`PHALPlugin` keeps the core lifecycle only: `register_core_events()` + the audio in/out, wake, sleep and speak handlers.

## Where the protocol goes
- **Listener side** — hardware enclosure plugins mix in `EnclosureProtocolListener` from [`ovos-ui-enclosure-protocol`](https://github.com/OpenVoiceOS/ovos-ui-enclosure-protocol) (the same wiring + no-op handlers, extracted verbatim).
- **Producer side** — `EnclosureAPI` lives in [`ovos-gui-api-client`](https://github.com/OpenVoiceOS/ovos-gui-api-client) alongside `GUIInterface`, so `self.gui` and `self.enclosure` come from one client.

Modern visual output is handled by `GUIInterface` (OVOS-GUI-1) and its template system.

## Tests
`test_phal_template_extended.py` reworked: drops the enclosure-handler/mouth-event tests, adds assertions that no `enclosure.*` subscriptions are wired and the abstraction's attributes are gone, and verifies the core-event register/shutdown wiring. Full suite green locally (965 passed; the one unrelated `langcodes` TTS-session failure is pre-existing and independent of this change).

Part of the enclosure→GUI migration (mk1 modeled as a GUI; abstraction dropped from core).


On hold: this removes the enclosure abstraction from PHALPlugin (ovos-PHAL-plugin-mk1#39 depends on it), which is GUI/enclosure work excluded from the current sprint.
