### PR TITLE
feat: add suppress_activation field to IntentHandlerMatch

### DIFF
--- a/ovos_plugin_manager/templates/pipeline.py
+++ b/ovos_plugin_manager/templates/pipeline.py
@@ -18,12 +18,18 @@ class IntentHandlerMatch:
         match_data (Optional[Dict]): Additional data provided by the intent match.
         skill_id (Optional[str]): The skill this handler belongs to.
         utterance (Optional[str]): The original utterance triggering the intent.
+        suppress_activation (bool): When True the orchestrator dispatches the
+            match without activating ``skill_id`` (no ``{skill_id}.activate``).
+            A termination or continuation of an already-active skill's
+            participation — e.g. a stop — sets this, since it must not register
+            the target as a freshly activated skill.
     """
     match_type: str
     match_data: Optional[Dict] = None
     skill_id: Optional[str] = None
     utterance: Optional[str] = None
     updated_session: Optional[Session] = None
+    suppress_activation: bool = False
 
 
 class PipelinePlugin:

--- a/test/unittests/test_pipeline.py
+++ b/test/unittests/test_pipeline.py
@@ -294,3 +294,16 @@ class TestOVOSPipelineFactory(unittest.TestCase):
             "my-pipe", bus=fake_bus, config={"key": "val"})
         self.assertIs(instance.bus, fake_bus)
         self.assertEqual(instance.config, {"key": "val"})
+
+
+class TestIntentHandlerMatchFields(unittest.TestCase):
+    def test_suppress_activation_defaults_false(self):
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        m = IntentHandlerMatch(match_type="x:intent", skill_id="x")
+        self.assertFalse(m.suppress_activation)
+
+    def test_suppress_activation_settable(self):
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        m = IntentHandlerMatch(match_type="x:stop", skill_id="x",
+                               suppress_activation=True)
+        self.assertTrue(m.suppress_activation)


### PR DESCRIPTION
Adds `suppress_activation: bool = False` to `IntentHandlerMatch` so a pipeline whose match terminates/continues an already-active skill (e.g. a stop, OVOS-STOP-1 §7.1) can tell the orchestrator to dispatch without activating `skill_id`. Defaults False — normal matches unaffected. Lets ovos-core read the field directly instead of via `getattr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)