### PR TITLE
feat: canonical transformer pipeline runner services

### DIFF
--- a/ovos_plugin_manager/dialog_transformers.py
+++ b/ovos_plugin_manager/dialog_transformers.py
@@ -1,6 +1,10 @@
-from ovos_plugin_manager.templates.transformers import DialogTransformer, TTSTransformer
+from ovos_plugin_manager.templates.transformers import DialogTransformer
 from ovos_plugin_manager.utils import PluginTypes
 from ovos_plugin_manager.utils import load_plugin, find_plugins
+# TTS transformer helpers live in ovos_plugin_manager.tts_transformers,
+# re-exported here for backwards compatibility
+from ovos_plugin_manager.tts_transformers import (find_tts_transformer_plugins,
+                                                  load_tts_transformer_plugin)
 
 
 def find_dialog_transformer_plugins() -> dict:
@@ -20,22 +24,3 @@ def load_dialog_transformer_plugin(module_name: str) -> type(DialogTransformer):
         class: found dialog_transformer plugin class
     """
     return load_plugin(module_name, PluginTypes.DIALOG_TRANSFORMER)
-
-
-def find_tts_transformer_plugins() -> dict:
-    """
-    Find all installed plugins
-    @return: dict plugin names to entrypoints
-    """
-    return find_plugins(PluginTypes.TTS_TRANSFORMER)
-
-
-def load_tts_transformer_plugin(module_name: str) -> type(TTSTransformer):
-    """Wrapper function for loading dialog_transformer plugin.
-
-    Arguments:
-        (str) OpenVoiceOS dialog_transformer module name from config
-    Returns:
-        class: found dialog_transformer plugin class
-    """
-    return load_plugin(module_name, PluginTypes.TTS_TRANSFORMER)

--- a/ovos_plugin_manager/templates/transformers.py
+++ b/ovos_plugin_manager/templates/transformers.py
@@ -306,7 +306,7 @@ class TTSTransformer:
         self.priority = priority
         if not config:
             config_core = dict(Configuration())
-            config = config_core.get("dialog_transformers", {}).get(self.name)
+            config = config_core.get("tts_transformers", {}).get(self.name)
         self.config = config or {}
 
     def bind(self, bus=None):

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -1,0 +1,302 @@
+"""Canonical runner services for transformer plugin pipelines.
+
+These services load, order and chain transformer plugins of each type
+(utterance, metadata, intent, dialog, tts, audio). They are the single
+shared implementation consumed by ovos-core, ovos-audio,
+ovos-dinkum-listener, hivemind and the ovos tts/stt servers.
+
+Loading is config-gated and opt-in: a plugin is only loaded if its name
+appears in the service's config section and its entry does not set
+``"active": false``.
+
+Ordering follows OVOS-TRANSFORM-1 §4: lower ``priority`` number runs
+first (``sort_ascending=True``, the default). Consumers that relied on
+the legacy descending traversal ("priority 1 runs last and wins") can
+pass ``sort_ascending=False``.
+"""
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from ovos_config import Configuration
+from ovos_utils.json_helper import merge_dict
+from ovos_utils.log import LOG
+
+from ovos_plugin_manager.audio_transformers import find_audio_transformer_plugins
+from ovos_plugin_manager.dialog_transformers import find_dialog_transformer_plugins
+from ovos_plugin_manager.intent_transformers import find_intent_transformer_plugins
+from ovos_plugin_manager.metadata_transformers import find_metadata_transformer_plugins
+from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+from ovos_plugin_manager.text_transformers import find_utterance_transformer_plugins
+from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
+
+
+class TransformersService:
+    """Base class for transformer pipeline runners.
+
+    Args:
+        bus: optional messagebus client, bound to plugins that support it
+        config: either the full core configuration (the service extracts
+            its own section) or the section mapping itself
+            (``{plugin_name: plugin_config}``). When omitted, the section
+            is read from ``Configuration()``.
+        sort_ascending: OVOS-TRANSFORM-1 §4 ordering (lower priority
+            number runs first). Set False for legacy descending order.
+    """
+    transformer_type: str = "generic"
+    config_section: Optional[str] = None
+    plugin_finder: Callable[[], Dict[str, Any]] = None
+
+    def __init__(self, bus=None, config: Optional[dict] = None,
+                 sort_ascending: bool = True):
+        self.bus = bus
+        self.loaded_plugins = {}
+        self.has_loaded = False
+        self.sort_ascending = sort_ascending
+        self.config = self._resolve_section(config)
+        self.load_plugins()
+
+    @classmethod
+    def _resolve_section(cls, config: Optional[dict]) -> dict:
+        """Accept either a full core config or the section mapping itself."""
+        if config is None:
+            config = Configuration()
+        if cls.config_section and cls.config_section in config:
+            return dict(config.get(cls.config_section) or {})
+        return dict(config)
+
+    @classmethod
+    def find_plugins(cls):
+        return cls.plugin_finder().items()
+
+    @classmethod
+    def get_available_plugins(cls) -> List[str]:
+        return list(cls.plugin_finder().keys())
+
+    def load_plugins(self) -> None:
+        for plug_name, plug in self.find_plugins():
+            if plug_name not in self.config:
+                continue
+            plug_config = self.config[plug_name] or {}
+            if isinstance(plug_config, dict) and not plug_config.get("active", True):
+                continue
+            try:
+                try:
+                    plugin = plug(config=plug_config)
+                except TypeError:
+                    # plugin does not accept a config kwarg, it self-reads
+                    # its section from Configuration()
+                    plugin = plug()
+                if self.bus:
+                    self._bind_plugin(plugin)
+                self.loaded_plugins[plug_name] = plugin
+                LOG.info(f"loaded {self.transformer_type} transformer plugin: {plug_name}")
+            except Exception:
+                LOG.exception(f"Failed to load {self.transformer_type} "
+                              f"transformer plugin: {plug_name}")
+        self.has_loaded = True
+
+    def _bind_plugin(self, plugin) -> None:
+        try:
+            plugin.bind(self.bus)
+        except Exception:
+            LOG.exception(f"Failed to bind bus to {self.transformer_type} "
+                          f"transformer plugin: {getattr(plugin, 'name', plugin)}")
+
+    def set_bus(self, bus) -> None:
+        """Attach (or replace) the messagebus and bind all loaded plugins."""
+        self.bus = bus
+        for plugin in self.loaded_plugins.values():
+            self._bind_plugin(plugin)
+
+    @property
+    def plugins(self) -> list:
+        """Loaded plugins in execution order.
+
+        With ``sort_ascending=True`` (OVOS-TRANSFORM-1 §4) a plugin with
+        ``priority=1`` runs first; later plugins see and may override its
+        output. With ``sort_ascending=False`` (legacy) a plugin with
+        ``priority=1`` runs last and has the final say.
+        """
+        return sorted(self.loaded_plugins.values(),
+                      key=lambda k: k.priority,
+                      reverse=not self.sort_ascending)
+
+    def shutdown(self) -> None:
+        for module in self.plugins:
+            try:
+                if hasattr(module, "shutdown"):
+                    module.shutdown()
+                else:
+                    module.default_shutdown()
+            except Exception as e:
+                LOG.warning(f"Error shutting down {getattr(module, 'name', module)}: {e}")
+
+
+class UtteranceTransformersService(TransformersService):
+    """Transforms utterances after STT and before intent matching."""
+    transformer_type = "utterance"
+    config_section = "utterance_transformers"
+    plugin_finder = staticmethod(find_utterance_transformer_plugins)
+
+    def transform(self, utterances: List[str],
+                  context: Optional[dict] = None) -> Tuple[List[str], dict]:
+        context = context or {}
+        for module in self.plugins:
+            try:
+                utterances, data = module.transform(utterances, context)
+                _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
+                LOG.debug(f"{module.name}: {_safe}")
+                context = merge_dict(context, data)
+            except Exception as e:
+                LOG.warning(f"{module.name} transform exception: {e}")
+        return utterances, context
+
+
+class MetadataTransformersService(TransformersService):
+    """Transforms message context after utterance transformers, before intent matching."""
+    transformer_type = "metadata"
+    config_section = "metadata_transformers"
+    plugin_finder = staticmethod(find_metadata_transformer_plugins)
+
+    def transform(self, context: Optional[dict] = None) -> dict:
+        context = context or {}
+        for module in self.plugins:
+            try:
+                data = module.transform(context)
+                _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
+                LOG.debug(f"{module.name}: {_safe}")
+                context = merge_dict(context, data)
+            except Exception as e:
+                LOG.warning(f"{module.name} transform exception: {e}")
+        return context
+
+
+class IntentTransformersService(TransformersService):
+    """Transforms the selected intent match before its handler is triggered."""
+    transformer_type = "intent"
+    config_section = "intent_transformers"
+    plugin_finder = staticmethod(find_intent_transformer_plugins)
+
+    def transform(self, intent: IntentHandlerMatch) -> IntentHandlerMatch:
+        for module in self.plugins:
+            try:
+                intent = module.transform(intent)
+                LOG.debug(f"{module.name}: {intent}")
+            except Exception as e:
+                LOG.warning(f"{module.name} transform exception: {e}")
+        return intent
+
+
+class DialogTransformersService(TransformersService):
+    """Transforms dialog text before it is sent to TTS."""
+    transformer_type = "dialog"
+    config_section = "dialog_transformers"
+    plugin_finder = staticmethod(find_dialog_transformer_plugins)
+
+    @property
+    def blacklisted_skills(self) -> List[str]:
+        # dialog should NEVER be rewritten if it comes from these skills
+        return self.config.get("blacklisted_skills",
+                               ["skill-ovos-icanhazdadjokes.openvoiceos"]  # blacklist jokes by default
+                               )
+
+    def transform(self, dialog: str, context: Optional[dict] = None,
+                  sess=None) -> Tuple[str, dict]:
+        """
+        @param dialog: str to be spoken
+        @return: transformed dialog to be sent to TTS
+        """
+        context = context or {}
+        for module in self.plugins:
+            try:
+                dialog, context = module.transform(dialog, context=context)
+                LOG.debug(f"{module.name}: {dialog}")
+            except Exception:
+                LOG.exception(f"{module.name} transform exception")
+        return dialog, context
+
+
+class TTSTransformersService(TransformersService):
+    """Transforms synthesized audio files after TTS and before playback."""
+    transformer_type = "tts"
+    config_section = "tts_transformers"
+    plugin_finder = staticmethod(find_tts_transformer_plugins)
+
+    def transform(self, wav_file: str, context: Optional[dict] = None,
+                  sess=None) -> Tuple[str, dict]:
+        """
+        @param wav_file: str path for the TTS wav file
+        @return: path to transformed wav file
+        """
+        context = context or {}
+        for module in self.plugins:
+            try:
+                wav_file, context = module.transform(wav_file, context=context)
+                LOG.debug(f"{module.name}: {wav_file}")
+            except Exception:
+                LOG.exception(f"{module.name} transform exception")
+        return wav_file, context
+
+
+class AudioTransformersService(TransformersService):
+    """Transforms raw audio before the STT stage."""
+    transformer_type = "audio"
+    config_section = "audio_transformers"
+    plugin_finder = staticmethod(find_audio_transformer_plugins)
+
+    def __init__(self, bus=None, config: Optional[dict] = None,
+                 sort_ascending: bool = True,
+                 default_context: Optional[dict] = None):
+        self.default_context = default_context or {}
+        super().__init__(bus=bus, config=config, sort_ascending=sort_ascending)
+
+    @classmethod
+    def _resolve_section(cls, config: Optional[dict]) -> dict:
+        if config is None:
+            config = Configuration()
+        # legacy location: nested under the "listener" section
+        listener = config.get("listener") or {}
+        if cls.config_section in listener:
+            if cls.config_section not in config:
+                LOG.warning("'listener.audio_transformers' is deprecated, "
+                            "move the section to top-level 'audio_transformers'")
+                return dict(listener.get(cls.config_section) or {})
+            # both defined: top-level wins, merged over legacy
+            return merge_dict(dict(listener.get(cls.config_section) or {}),
+                              dict(config.get(cls.config_section) or {}))
+        return super()._resolve_section(config)
+
+    def feed_audio(self, chunk: bytes) -> None:
+        """Feed a chunk of untagged (not speech) audio to all loaded plugins."""
+        for module in self.plugins:
+            module.feed_audio_chunk(chunk)
+
+    def feed_hotword(self, chunk: bytes) -> None:
+        """Feed a chunk of hotword audio to all loaded plugins."""
+        for module in self.plugins:
+            module.feed_hotword_chunk(chunk)
+
+    def feed_speech(self, chunk: bytes) -> None:
+        """Feed a chunk of speech audio to all loaded plugins."""
+        try:
+            for module in self.plugins:
+                module.feed_speech_chunk(chunk)
+        except Exception:
+            LOG.exception("error feeding speech chunk to audio transformers")
+
+    def transform(self, chunk: bytes,
+                  context: Optional[dict] = None) -> Tuple[bytes, dict]:
+        """
+        Get transformed audio and context for the preceding audio
+        @param chunk: bytes of audio data
+        @return: transformed audio data, dict context
+        """
+        context = context or dict(self.default_context)
+        for module in self.plugins:
+            try:
+                chunk = module.feed_speech_utterance(chunk)
+                chunk, data = module.transform(chunk)
+                LOG.debug(f"{module.name}: {data}")
+                context = merge_dict(context, data)
+            except Exception:
+                LOG.exception(f"{module.name} transform exception")
+        return chunk, context

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -51,6 +51,7 @@ class TransformersService:
         self.loaded_plugins = {}
         self.has_loaded = False
         self.sort_ascending = sort_ascending
+        self._sorted_plugins = None
         self.config = self._resolve_section(config)
         self.load_plugins()
 
@@ -92,6 +93,7 @@ class TransformersService:
             except Exception:
                 LOG.exception(f"Failed to load {self.transformer_type} "
                               f"transformer plugin: {plug_name}")
+        self._sorted_plugins = None
         self.has_loaded = True
 
     def _bind_plugin(self, plugin) -> None:
@@ -116,9 +118,11 @@ class TransformersService:
         output. With ``sort_ascending=False`` (legacy) a plugin with
         ``priority=1`` runs last and has the final say.
         """
-        return sorted(self.loaded_plugins.values(),
-                      key=lambda k: k.priority,
-                      reverse=not self.sort_ascending)
+        if self._sorted_plugins is None:
+            self._sorted_plugins = sorted(self.loaded_plugins.values(),
+                                          key=lambda k: k.priority,
+                                          reverse=not self.sort_ascending)
+        return self._sorted_plugins
 
     def shutdown(self) -> None:
         for module in self.plugins:

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -9,10 +9,19 @@ Loading is config-gated and opt-in: a plugin is only loaded if its name
 appears in the service's config section and its entry does not set
 ``"active": false``.
 
-Ordering follows OVOS-TRANSFORM-1 §4: lower ``priority`` number runs
-first (``sort_ascending=True``, the default). Consumers that relied on
-the legacy descending traversal ("priority 1 runs last and wins") can
-pass ``sort_ascending=False``.
+Ordering follows OVOS-TRANSFORM §4: lower ``priority`` number runs
+first (``sort_ascending=True``, the default). An explicit deployer
+order — an ``"order"`` list of plugin names in the config section —
+wins over priorities; loaded plugins absent from that list are not
+run. Consumers that relied on the legacy descending traversal
+("priority 1 runs last and wins") can pass ``sort_ascending=False``;
+this escape hatch is deprecated and will be removed.
+
+Cancellation follows OVOS-TRANSFORM §8.1: a plugin signals by
+returning both ``"canceled": true`` and ``"cancel_reason"`` in its
+context; the runner stamps ``"cancel_by"`` and stops the chain. An
+incomplete pair is a shape violation: logged, stripped, chain
+continues. Terminal bus events (§8.2) are the consumer's concern.
 """
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -73,10 +82,17 @@ class TransformersService:
         return list(cls.plugin_finder().keys())
 
     def load_plugins(self) -> None:
+        # reserved config keys that are not plugin entries
+        enabled = set(self.config.keys()) - {"order", "blacklisted_skills"}
+        explicit_order = self.config.get("order")
+        if isinstance(explicit_order, list):
+            # plugins in the explicit chain are enabled even without
+            # their own config entry
+            enabled |= set(explicit_order)
         for plug_name, plug in self.find_plugins():
-            if plug_name not in self.config:
+            if plug_name not in enabled:
                 continue
-            plug_config = self.config[plug_name] or {}
+            plug_config = self.config.get(plug_name) or {}
             if isinstance(plug_config, dict) and not plug_config.get("active", True):
                 continue
             try:
@@ -113,16 +129,51 @@ class TransformersService:
     def plugins(self) -> list:
         """Loaded plugins in execution order.
 
-        With ``sort_ascending=True`` (OVOS-TRANSFORM-1 §4) a plugin with
-        ``priority=1`` runs first; later plugins see and may override its
-        output. With ``sort_ascending=False`` (legacy) a plugin with
-        ``priority=1`` runs last and has the final say.
+        An explicit deployer order (an ``"order"`` list of plugin names in
+        the config section) wins over priorities per OVOS-TRANSFORM §4;
+        loaded plugins absent from the list are not run.
+
+        Otherwise, with ``sort_ascending=True`` (OVOS-TRANSFORM §4) a
+        plugin with ``priority=1`` runs first; later plugins see and may
+        override its output. With ``sort_ascending=False`` (deprecated
+        legacy behavior) a plugin with ``priority=1`` runs last and has
+        the final say.
         """
         if self._sorted_plugins is None:
-            self._sorted_plugins = sorted(self.loaded_plugins.values(),
-                                          key=lambda k: k.priority,
-                                          reverse=not self.sort_ascending)
+            explicit_order = self.config.get("order")
+            if isinstance(explicit_order, list):
+                self._sorted_plugins = [self.loaded_plugins[name]
+                                        for name in explicit_order
+                                        if name in self.loaded_plugins]
+            else:
+                self._sorted_plugins = sorted(self.loaded_plugins.values(),
+                                              key=lambda k: k.priority,
+                                              reverse=not self.sort_ascending)
         return self._sorted_plugins
+
+    def _check_cancellation(self, data: dict, module) -> bool:
+        """Validate a §8.1 cancellation signal in a plugin's returned context.
+
+        Returns True when a valid ``canceled``/``cancel_reason`` pair is
+        present, stamping ``cancel_by`` from the emitting plugin (never
+        from a value the plugin set itself). An incomplete pair is a
+        shape violation: logged, stripped from ``data`` in place, and the
+        chain proceeds as if the plugin returned its input unchanged.
+        """
+        if not isinstance(data, dict):
+            return False
+        if data.get("canceled") is True and data.get("cancel_reason"):
+            data["cancel_by"] = module.name
+            LOG.info(f"{self.transformer_type} chain canceled by "
+                     f"{module.name}: {data['cancel_reason']}")
+            return True
+        if "canceled" in data or "cancel_reason" in data:
+            LOG.warning(f"{module.name} signalled an incomplete cancellation "
+                        "pair (OVOS-TRANSFORM §8.1 requires both 'canceled' "
+                        "and 'cancel_reason'), ignoring it")
+            data.pop("canceled", None)
+            data.pop("cancel_reason", None)
+        return False
 
     def shutdown(self) -> None:
         for module in self.plugins:
@@ -149,7 +200,10 @@ class UtteranceTransformersService(TransformersService):
                 utterances, data = module.transform(utterances, context)
                 _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
                 LOG.debug(f"{module.name}: {_safe}")
+                canceled = self._check_cancellation(data, module)
                 context = merge_dict(context, data)
+                if canceled:
+                    break
             except Exception as e:
                 LOG.warning(f"{module.name} transform exception: {e}")
         return utterances, context
@@ -168,7 +222,10 @@ class MetadataTransformersService(TransformersService):
                 data = module.transform(context)
                 _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
                 LOG.debug(f"{module.name}: {_safe}")
+                canceled = self._check_cancellation(data, module)
                 context = merge_dict(context, data)
+                if canceled:
+                    break
             except Exception as e:
                 LOG.warning(f"{module.name} transform exception: {e}")
         return context
@@ -214,6 +271,8 @@ class DialogTransformersService(TransformersService):
             try:
                 dialog, context = module.transform(dialog, context=context)
                 LOG.debug(f"{module.name}: {dialog}")
+                if self._check_cancellation(context, module):
+                    break
             except Exception:
                 LOG.exception(f"{module.name} transform exception")
         return dialog, context
@@ -236,6 +295,8 @@ class TTSTransformersService(TransformersService):
             try:
                 wav_file, context = module.transform(wav_file, context=context)
                 LOG.debug(f"{module.name}: {wav_file}")
+                if self._check_cancellation(context, module):
+                    break
             except Exception:
                 LOG.exception(f"{module.name} transform exception")
         return wav_file, context
@@ -300,7 +361,10 @@ class AudioTransformersService(TransformersService):
                 chunk = module.feed_speech_utterance(chunk)
                 chunk, data = module.transform(chunk)
                 LOG.debug(f"{module.name}: {data}")
+                canceled = self._check_cancellation(data, module)
                 context = merge_dict(context, data)
+                if canceled:
+                    break
             except Exception:
                 LOG.exception(f"{module.name} transform exception")
         return chunk, context

--- a/ovos_plugin_manager/tts_transformers.py
+++ b/ovos_plugin_manager/tts_transformers.py
@@ -1,0 +1,22 @@
+from ovos_plugin_manager.templates.transformers import TTSTransformer
+from ovos_plugin_manager.utils import PluginTypes
+from ovos_plugin_manager.utils import load_plugin, find_plugins
+
+
+def find_tts_transformer_plugins() -> dict:
+    """
+    Find all installed plugins
+    @return: dict plugin names to entrypoints
+    """
+    return find_plugins(PluginTypes.TTS_TRANSFORMER)
+
+
+def load_tts_transformer_plugin(module_name: str) -> type(TTSTransformer):
+    """Wrapper function for loading tts_transformer plugin.
+
+    Arguments:
+        (str) OpenVoiceOS tts_transformer module name from config
+    Returns:
+        class: found tts_transformer plugin class
+    """
+    return load_plugin(module_name, PluginTypes.TTS_TRANSFORMER)

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -112,6 +112,112 @@ class TestPriorityOrdering(unittest.TestCase):
         self.assertEqual(utterances, ["first:last:hello"])
 
 
+class TestExplicitOrder(unittest.TestCase):
+    """OVOS-TRANSFORM §4: explicit deployer order wins over priorities."""
+
+    def _service(self, config):
+        plugins = {"plug-a": _UttPrefixer, "plug-b": _UttPrefixer,
+                   "plug-c": _UttPrefixer}
+        with patch.object(UtteranceTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder(plugins))):
+            service = UtteranceTransformersService(config=config)
+        for name, plugin in service.loaded_plugins.items():
+            plugin.name = name
+        return service
+
+    def test_order_overrides_priorities(self):
+        service = self._service({"plug-a": {"priority": 1}, "plug-b": {},
+                                 "order": ["plug-b", "plug-a"]})
+        self.assertEqual([p.name for p in service.plugins],
+                         ["plug-b", "plug-a"])
+
+    def test_loaded_but_unlisted_plugins_do_not_run(self):
+        service = self._service({"plug-a": {}, "plug-b": {},
+                                 "order": ["plug-b"]})
+        self.assertEqual([p.name for p in service.plugins], ["plug-b"])
+
+    def test_order_enables_plugins_without_config_entry(self):
+        service = self._service({"order": ["plug-c"]})
+        self.assertEqual(list(service.loaded_plugins), ["plug-c"])
+
+    def test_order_key_is_not_a_plugin(self):
+        service = self._service({"plug-a": {}, "order": ["plug-a"]})
+        self.assertNotIn("order", service.loaded_plugins)
+
+
+class TestCancellation(unittest.TestCase):
+    """OVOS-TRANSFORM §8.1 cancellation signal handling."""
+
+    class _Canceller(UtteranceTransformer):
+        def __init__(self, name="canceller", priority=1, data=None):
+            super().__init__(name, priority, {})
+            self.data = data or {"canceled": True, "cancel_reason": "stop_word"}
+
+        def transform(self, utterances, context=None):
+            return utterances, dict(self.data)
+
+    def _service(self, *plugins):
+        with patch.object(UtteranceTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({}))):
+            service = UtteranceTransformersService(config={})
+        for p in plugins:
+            service.loaded_plugins[p.name] = p
+        return service
+
+    def test_valid_signal_stops_chain_and_stamps_cancel_by(self):
+        late = _UttPrefixer("late", priority=99)
+        service = self._service(self._Canceller(), late)
+        utterances, context = service.transform(["hi"])
+        self.assertEqual(utterances, ["hi"])  # late plugin never ran
+        self.assertTrue(context["canceled"])
+        self.assertEqual(context["cancel_reason"], "stop_word")
+        self.assertEqual(context["cancel_by"], "canceller")
+
+    def test_cancel_by_cannot_be_spoofed(self):
+        canceller = self._Canceller(data={"canceled": True,
+                                          "cancel_reason": "policy_block",
+                                          "cancel_by": "someone-else"})
+        service = self._service(canceller)
+        _, context = service.transform(["hi"])
+        self.assertEqual(context["cancel_by"], "canceller")
+
+    def test_incomplete_pair_is_stripped_and_chain_continues(self):
+        canceller = self._Canceller(data={"canceled": True})  # no reason
+        late = _UttPrefixer("late", priority=99)
+        service = self._service(canceller, late)
+        utterances, context = service.transform(["hi"])
+        self.assertEqual(utterances, ["late:hi"])
+        self.assertNotIn("canceled", context)
+        self.assertNotIn("cancel_by", context)
+
+    def test_reason_without_canceled_is_stripped(self):
+        canceller = self._Canceller(data={"cancel_reason": "stop_word"})
+        service = self._service(canceller)
+        _, context = service.transform(["hi"])
+        self.assertNotIn("cancel_reason", context)
+
+    def test_dialog_chain_cancellation(self):
+        class CancellingDialog(DialogTransformer):
+            def transform(self, dialog, context=None):
+                context = context or {}
+                context.update({"canceled": True,
+                                "cancel_reason": "policy_block"})
+                return dialog, context
+
+        class Upper(DialogTransformer):
+            def transform(self, dialog, context=None):
+                return dialog.upper(), context or {}
+
+        with patch.object(DialogTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({}))):
+            service = DialogTransformersService(config={})
+        service.loaded_plugins["c"] = CancellingDialog("c", priority=1)
+        service.loaded_plugins["u"] = Upper("u", priority=99)
+        dialog, context = service.transform("hello")
+        self.assertEqual(dialog, "hello")  # chain stopped before Upper
+        self.assertEqual(context["cancel_by"], "c")
+
+
 class TestBusBinding(unittest.TestCase):
 
     def test_bus_bound_on_load(self):

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -1,0 +1,285 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from ovos_plugin_manager.templates.transformers import (AudioTransformer,
+                                                        DialogTransformer,
+                                                        MetadataTransformer,
+                                                        TTSTransformer,
+                                                        UtteranceTransformer)
+from ovos_plugin_manager.transformer_services import (
+    AudioTransformersService, DialogTransformersService,
+    IntentTransformersService, MetadataTransformersService,
+    TTSTransformersService, UtteranceTransformersService)
+
+
+class _UttPrefixer(UtteranceTransformer):
+    def __init__(self, name="prefixer", priority=50, config=None):
+        super().__init__(name, priority, config or {})
+
+    def transform(self, utterances, context=None):
+        return [f"{self.name}:{u}" for u in utterances], {self.name: True}
+
+
+def _fake_finder(plugins):
+    return lambda: plugins
+
+
+class TestLoadingGate(unittest.TestCase):
+
+    def _service(self, config):
+        with patch.object(UtteranceTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({"plug-a": _UttPrefixer,
+                                                     "plug-b": _UttPrefixer}))):
+            return UtteranceTransformersService(config=config)
+
+    def test_optin_only_named_plugins_load(self):
+        service = self._service({"plug-a": {}})
+        self.assertEqual(list(service.loaded_plugins), ["plug-a"])
+        self.assertTrue(service.has_loaded)
+
+    def test_inactive_plugin_skipped(self):
+        service = self._service({"plug-a": {"active": False}, "plug-b": {}})
+        self.assertEqual(list(service.loaded_plugins), ["plug-b"])
+
+    def test_empty_config_loads_nothing(self):
+        service = self._service({})
+        self.assertEqual(service.loaded_plugins, {})
+
+    def test_full_core_config_section_extracted(self):
+        service = self._service({"utterance_transformers": {"plug-a": {}},
+                                 "lang": "en-US"})
+        self.assertEqual(list(service.loaded_plugins), ["plug-a"])
+
+    def test_plugin_receives_config(self):
+        plug = Mock()
+        with patch.object(UtteranceTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({"plug-a": plug}))):
+            UtteranceTransformersService(config={"plug-a": {"key": "val"}})
+        plug.assert_called_once_with(config={"key": "val"})
+
+    def test_plugin_without_config_kwarg_falls_back(self):
+        class NoConfigPlugin:
+            def __init__(self):
+                self.priority = 50
+                self.name = "no-config"
+
+        def strict_ctor(config=None):
+            if config is not None:
+                raise TypeError("unexpected keyword argument")
+            return NoConfigPlugin()
+
+        # simulate a plugin class whose ctor rejects config=
+        plug = Mock(side_effect=[TypeError("no kwarg"), NoConfigPlugin()])
+        with patch.object(UtteranceTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({"plug-a": plug}))):
+            service = UtteranceTransformersService(config={"plug-a": {}})
+        self.assertIn("plug-a", service.loaded_plugins)
+
+    def test_failed_plugin_does_not_break_loading(self):
+        bad = Mock(side_effect=Exception("boom"))
+        with patch.object(UtteranceTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({"bad": bad,
+                                                     "plug-a": _UttPrefixer}))):
+            service = UtteranceTransformersService(config={"bad": {}, "plug-a": {}})
+        self.assertEqual(list(service.loaded_plugins), ["plug-a"])
+
+
+class TestPriorityOrdering(unittest.TestCase):
+
+    def _service(self, sort_ascending=True):
+        first = _UttPrefixer("first", priority=1)
+        last = _UttPrefixer("last", priority=99)
+        service = UtteranceTransformersService.__new__(UtteranceTransformersService)
+        service.bus = None
+        service.sort_ascending = sort_ascending
+        service.loaded_plugins = {"first": first, "last": last}
+        service.config = {}
+        service.has_loaded = True
+        return service
+
+    def test_ascending_default_low_priority_runs_first(self):
+        service = self._service(sort_ascending=True)
+        self.assertEqual([p.name for p in service.plugins], ["first", "last"])
+        utterances, context = service.transform(["hello"])
+        self.assertEqual(utterances, ["last:first:hello"])
+        self.assertEqual(context, {"first": True, "last": True})
+
+    def test_legacy_descending_low_priority_runs_last(self):
+        service = self._service(sort_ascending=False)
+        self.assertEqual([p.name for p in service.plugins], ["last", "first"])
+        utterances, _ = service.transform(["hello"])
+        self.assertEqual(utterances, ["first:last:hello"])
+
+
+class TestBusBinding(unittest.TestCase):
+
+    def test_bus_bound_on_load(self):
+        bus = Mock()
+        plugin = Mock()
+        plug = Mock(return_value=plugin)
+        with patch.object(IntentTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({"plug-a": plug}))):
+            IntentTransformersService(bus=bus, config={"plug-a": {}})
+        plugin.bind.assert_called_once_with(bus)
+
+    def test_no_bind_without_bus(self):
+        plugin = Mock()
+        plug = Mock(return_value=plugin)
+        with patch.object(IntentTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({"plug-a": plug}))):
+            IntentTransformersService(config={"plug-a": {}})
+        plugin.bind.assert_not_called()
+
+    def test_set_bus_binds_loaded_plugins(self):
+        bus = Mock()
+        plugin = Mock()
+        plug = Mock(return_value=plugin)
+        with patch.object(TTSTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({"plug-a": plug}))):
+            service = TTSTransformersService(config={"plug-a": {}})
+        service.set_bus(bus)
+        plugin.bind.assert_called_once_with(bus)
+
+
+class TestServiceTransforms(unittest.TestCase):
+
+    def _empty(self, klass, **kwargs):
+        with patch.object(klass, "plugin_finder", staticmethod(_fake_finder({}))):
+            return klass(config={}, **kwargs)
+
+    def test_metadata_transform(self):
+        class Meta(MetadataTransformer):
+            def transform(self, context=None):
+                return {"injected": True}
+
+        service = self._empty(MetadataTransformersService)
+        service.loaded_plugins["m"] = Meta("m")
+        context = service.transform({"seed": 1})
+        self.assertEqual(context, {"seed": 1, "injected": True})
+
+    def test_dialog_transform(self):
+        class Dialog(DialogTransformer):
+            def transform(self, dialog, context=None):
+                return dialog.upper(), context or {}
+
+        service = self._empty(DialogTransformersService)
+        service.loaded_plugins["d"] = Dialog("d")
+        dialog, _ = service.transform("hello")
+        self.assertEqual(dialog, "HELLO")
+
+    def test_dialog_blacklisted_skills_default(self):
+        service = self._empty(DialogTransformersService)
+        self.assertIn("skill-ovos-icanhazdadjokes.openvoiceos",
+                      service.blacklisted_skills)
+
+    def test_tts_transform(self):
+        class Tts(TTSTransformer):
+            def transform(self, wav_file, context=None):
+                return wav_file + ".transformed", context or {}
+
+        service = self._empty(TTSTransformersService)
+        service.loaded_plugins["t"] = Tts("t")
+        wav, _ = service.transform("/tmp/audio.wav")
+        self.assertEqual(wav, "/tmp/audio.wav.transformed")
+
+    def test_plugin_exception_does_not_break_chain(self):
+        class Boom(UtteranceTransformer):
+            def transform(self, utterances, context=None):
+                raise RuntimeError("boom")
+
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["boom"] = Boom("boom", priority=1)
+        service.loaded_plugins["ok"] = _UttPrefixer("ok", priority=2)
+        utterances, _ = service.transform(["hi"])
+        self.assertEqual(utterances, ["ok:hi"])
+
+    def test_shutdown_swallows_errors(self):
+        plugin = Mock()
+        plugin.shutdown.side_effect = Exception("boom")
+        plugin.priority = 50
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["p"] = plugin
+        service.shutdown()  # must not raise
+        plugin.shutdown.assert_called_once()
+
+
+class TestAudioTransformersService(unittest.TestCase):
+
+    def _empty(self, **kwargs):
+        with patch.object(AudioTransformersService, "plugin_finder",
+                          staticmethod(_fake_finder({}))):
+            return AudioTransformersService(**kwargs)
+
+    def test_top_level_config_section(self):
+        service = self._empty(config={"audio_transformers": {"plug-a": {}}})
+        self.assertEqual(service.config, {"plug-a": {}})
+
+    def test_legacy_listener_nested_section(self):
+        service = self._empty(
+            config={"listener": {"audio_transformers": {"plug-a": {}}}})
+        self.assertEqual(service.config, {"plug-a": {}})
+
+    def test_top_level_wins_over_legacy(self):
+        service = self._empty(config={
+            "audio_transformers": {"plug-a": {"x": 2}},
+            "listener": {"audio_transformers": {"plug-a": {"x": 1},
+                                                "plug-b": {}}}})
+        self.assertEqual(service.config,
+                         {"plug-a": {"x": 2}, "plug-b": {}})
+
+    def test_transform_merges_context_over_default(self):
+        class Audio(AudioTransformer):
+            def __init__(self):
+                super().__init__("lang-detect", config={})
+
+            def transform(self, audio_data):
+                return audio_data, {"stt_lang": "pt-PT"}
+
+        service = self._empty(config={},
+                              default_context={"source": "audio"})
+        service.loaded_plugins["a"] = Audio()
+        chunk, context = service.transform(b"audio-bytes")
+        self.assertEqual(chunk, b"audio-bytes")
+        self.assertEqual(context, {"source": "audio", "stt_lang": "pt-PT"})
+
+    def test_feed_helpers_reach_plugins(self):
+        plugin = Mock()
+        plugin.priority = 50
+        service = self._empty(config={})
+        service.loaded_plugins["a"] = plugin
+        service.feed_audio(b"1")
+        service.feed_hotword(b"2")
+        service.feed_speech(b"3")
+        plugin.feed_audio_chunk.assert_called_once_with(b"1")
+        plugin.feed_hotword_chunk.assert_called_once_with(b"2")
+        plugin.feed_speech_chunk.assert_called_once_with(b"3")
+
+
+class TestTTSTransformerTemplateConfig(unittest.TestCase):
+
+    @patch("ovos_plugin_manager.templates.transformers.Configuration")
+    def test_reads_tts_transformers_section(self, config):
+        config.return_value = {"tts_transformers": {"my-plug": {"pitch": 2}},
+                               "dialog_transformers": {"my-plug": {"pitch": 1}}}
+        plugin = TTSTransformer("my-plug")
+        self.assertEqual(plugin.config, {"pitch": 2})
+
+
+class TestTTSTransformersModule(unittest.TestCase):
+
+    @patch("ovos_plugin_manager.tts_transformers.find_plugins")
+    def test_find_plugins(self, find_plugins):
+        from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
+        from ovos_plugin_manager.utils import PluginTypes
+        find_tts_transformer_plugins()
+        find_plugins.assert_called_once_with(PluginTypes.TTS_TRANSFORMER)
+
+    def test_backwards_compat_reexport(self):
+        from ovos_plugin_manager.dialog_transformers import (
+            find_tts_transformer_plugins, load_tts_transformer_plugin)
+        self.assertTrue(callable(find_tts_transformer_plugins))
+        self.assertTrue(callable(load_tts_transformer_plugin))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -92,6 +92,7 @@ class TestPriorityOrdering(unittest.TestCase):
         service = UtteranceTransformersService.__new__(UtteranceTransformersService)
         service.bus = None
         service.sort_ascending = sort_ascending
+        service._sorted_plugins = None
         service.loaded_plugins = {"first": first, "last": last}
         service.config = {}
         service.has_loaded = True

--- a/test/unittests/test_transformers.py
+++ b/test/unittests/test_transformers.py
@@ -293,7 +293,7 @@ class TestTransformerPluginUtils(unittest.TestCase):
         find_audio_transformer_plugins()
         mock_find.assert_called_once_with(PluginTypes.AUDIO_TRANSFORMER)
 
-    @patch("ovos_plugin_manager.utils.find_plugins")
+    @patch("ovos_plugin_manager.dialog_transformers.find_plugins")
     def test_find_dialog_transformers(self, mock_find):
         from ovos_plugin_manager.dialog_transformers import find_dialog_transformer_plugins
         find_dialog_transformer_plugins()


### PR DESCRIPTION
## What

Adds `ovos_plugin_manager.transformer_services` — a single shared implementation of the six transformer pipeline runners (`UtteranceTransformersService`, `MetadataTransformersService`, `IntentTransformersService`, `DialogTransformersService`, `TTSTransformersService`, `AudioTransformersService`).

These runner classes are currently copy-pasted with behavioral drift across ovos-core, ovos-audio, ovos-dinkum-listener and hivemind-audio-binary-protocol. This module becomes the canonical implementation for all of them, and for new consumers (ovos-tts-server, ovos-stt-http-server, hivemind-core, hivemind satellites).

## Unified behavior

- **Loading** is config-gated and opt-in: a plugin loads only if named in the service's config section and not `"active": false`.
- **Config injection**: services accept either the full core configuration (section extracted automatically) or the section mapping itself, so non-mycroft.conf consumers can inject plain dicts. Plugin configs are passed explicitly to plugin constructors, with a fallback for plugins whose constructor takes no `config` kwarg.
- **Ordering**: OVOS-TRANSFORM-1 §4 ascending priority (lower number runs first) by default; consumers that rely on the legacy descending traversal ("priority 1 runs last and wins") pass `sort_ascending=False`.
- **Bus binding**: optional at construction, or later via `set_bus()`.
- **Audio config location**: supports top-level `audio_transformers` and the legacy `listener.audio_transformers` section (top-level wins, deprecation warning for the nested form).

## Fixes

- `TTSTransformer.__init__` read its config from the `dialog_transformers` section instead of `tts_transformers`.
- TTS transformer discovery helpers move from `dialog_transformers.py` to a dedicated `tts_transformers.py` module, with backwards-compatible re-exports kept in place.

## Tests

`test/unittests/test_transformer_services.py` covers the loading gate, config-section resolution (full config vs section, legacy listener nesting), both priority orderings, bus binding, per-type transform chains, error isolation, and the template/module fixes.

Downstream adoption (ovos-core, ovos-audio, ovos-dinkum-listener, hivemind) follows in separate PRs once this releases as an alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable transformer services for utterance, metadata, intent, dialog, TTS, and audio processing.
  - Added plugin ordering, cancellation handling, error isolation, bus integration, and audio streaming support.
  - Added dedicated helpers for discovering and loading TTS transformer plugins.

- **Bug Fixes**
  - Corrected TTS transformer configuration loading to use the appropriate configuration section.

- **Compatibility**
  - Preserved existing TTS transformer discovery and loading imports through backwards-compatible re-exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->