### PR TITLE
fix: stop internal wiring from firing deprecation notices

### DIFF
--- a/ovos_plugin_manager/__init__.py
+++ b/ovos_plugin_manager/__init__.py
@@ -1,2 +1,11 @@
 from ovos_plugin_manager.utils import PluginTypes
-from ovos_plugin_manager.plugin_entry import OpenVoiceOSPlugin
+
+
+def __getattr__(name):
+    # OpenVoiceOSPlugin lives in the deprecated plugin_entry module; importing
+    # it lazily keeps `from ovos_plugin_manager import OpenVoiceOSPlugin`
+    # working without dragging the deprecated module into every package import.
+    if name == "OpenVoiceOSPlugin":
+        from ovos_plugin_manager.plugin_entry import OpenVoiceOSPlugin
+        return OpenVoiceOSPlugin
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ovos_plugin_manager/_deprecation.py
+++ b/ovos_plugin_manager/_deprecation.py
@@ -1,0 +1,18 @@
+import inspect
+
+
+def imported_internally(module_name: str) -> bool:
+    """Whether this import was triggered by ovos_plugin_manager wiring itself
+    together rather than by an external caller.
+
+    A module-level deprecation notice is a message to external callers. When
+    one deprecated module imports another to assemble the package, firing that
+    notice only produces log noise whose origin is the library itself, so the
+    internal case is detected here and the notice is skipped for it.
+    """
+    for frame_info in inspect.stack()[1:]:
+        name = frame_info.frame.f_globals.get("__name__", "")
+        if name == module_name or name.startswith("importlib"):
+            continue
+        return name.startswith("ovos_plugin_manager")
+    return False

--- a/ovos_plugin_manager/installation.py
+++ b/ovos_plugin_manager/installation.py
@@ -9,16 +9,18 @@ from combo_lock import NamedLock
 from ovos_utils.log import LOG, log_deprecation, deprecated
 
 from ovos_plugin_manager.exceptions import PipException
+from ovos_plugin_manager._deprecation import imported_internally
 from ovos_plugin_manager.version import VERSION_MAJOR
 
 # Calculate next major version for deprecation
 _deprecation_version = f"{VERSION_MAJOR + 1}.0"
 
-# Deprecation notice for this module
-log_deprecation(f"ovos_plugin_manager.installation module is deprecated and will be removed in v{_deprecation_version}",
-                func_name="installation module",
-                func_module="ovos_plugin_manager.installation",
-                deprecation_version=_deprecation_version)
+# Deprecation notice for external callers of this module
+if not imported_internally(__name__):
+    log_deprecation(f"ovos_plugin_manager.installation module is deprecated and will be removed in v{_deprecation_version}",
+                    func_name="installation module",
+                    func_module="ovos_plugin_manager.installation",
+                    deprecation_version=_deprecation_version)
 
 # default constraints to use if none are given
 DEFAULT_CONSTRAINTS = '/etc/mycroft/constraints.txt'

--- a/ovos_plugin_manager/plugin_entry.py
+++ b/ovos_plugin_manager/plugin_entry.py
@@ -9,16 +9,18 @@ from ovos_plugin_manager.installation import pip_install
 from ovos_utils import camel_case_split
 from ovos_utils.json_helper import merge_dict
 from ovos_utils.log import log_deprecation
+from ovos_plugin_manager._deprecation import imported_internally
 from ovos_plugin_manager.version import VERSION_MAJOR
 
 # Calculate next major version for deprecation
 _deprecation_version = f"{VERSION_MAJOR + 1}.0"
 
-# Deprecation notice for this module
-log_deprecation(f"ovos_plugin_manager.plugin_entry module is deprecated and will be removed in v{_deprecation_version}",
-                func_name="plugin_entry module",
-                func_module="ovos_plugin_manager.plugin_entry",
-                deprecation_version=_deprecation_version)
+# Deprecation notice for external callers of this module
+if not imported_internally(__name__):
+    log_deprecation(f"ovos_plugin_manager.plugin_entry module is deprecated and will be removed in v{_deprecation_version}",
+                    func_name="plugin_entry module",
+                    func_module="ovos_plugin_manager.plugin_entry",
+                    deprecation_version=_deprecation_version)
 
 
 class OpenVoiceOSPlugin:

--- a/ovos_plugin_manager/solvers.py
+++ b/ovos_plugin_manager/solvers.py
@@ -2,14 +2,6 @@ from ovos_plugin_manager.templates.solvers import QuestionSolver, TldrSolver, \
     EntailmentSolver, MultipleChoiceSolver, EvidenceSolver, ChatMessageSolver
 from ovos_plugin_manager.utils import PluginTypes, PluginConfigTypes
 
-from ovos_utils.log import log_deprecation
-from ovos_plugin_manager.version import VERSION_MAJOR
-
-log_deprecation("solver plugins have been deprecated and will be removed in the next major release.\n"
-                "Please migrate your code to use AbstractAgentEngine.\n"
-                "The new classes live in ovos_plugin_manager.templates.agents",
-                f"{VERSION_MAJOR + 1}.0.0")
-
 
 def find_chat_solver_plugins() -> dict:
     """

--- a/ovos_plugin_manager/templates/solvers.py
+++ b/ovos_plugin_manager/templates/solvers.py
@@ -8,14 +8,16 @@ from ovos_spec_tools import standardize_lang
 from ovos_utils.log import LOG, log_deprecation, deprecated
 from ovos_utils.xdg_utils import xdg_cache_home
 
+from ovos_plugin_manager._deprecation import imported_internally
 from ovos_plugin_manager.templates.language import LanguageTranslator, LanguageDetector
 from ovos_plugin_manager.thirdparty.solvers import AbstractSolver
 from ovos_plugin_manager.version import VERSION_MAJOR
 
-log_deprecation("ovos_plugin_manager.templates.solvers has been deprecated and will be removed in the next major release.\n"
-                "Please migrate your code to use AbstractAgentEngine.\n"
-                "The new classes live in ovos_plugin_manager.templates.agents",
-                f"{VERSION_MAJOR + 1}.0.0")
+if not imported_internally(__name__):
+    log_deprecation("ovos_plugin_manager.templates.solvers has been deprecated and will be removed in the next major release.\n"
+                    "Please migrate your code to use AbstractAgentEngine.\n"
+                    "The new classes live in ovos_plugin_manager.templates.agents",
+                    f"{VERSION_MAJOR + 1}.0.0")
 
 
 def auto_translate(translate_keys: List[str], translate_str_args=True):

--- a/test/unittests/test_deprecation_noise.py
+++ b/test/unittests/test_deprecation_noise.py
@@ -1,0 +1,61 @@
+# Copyright 2024, OpenVoiceOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wiring ovos_plugin_manager together must not fire its own deprecation
+notices, while an external caller importing a deprecated module still gets
+warned exactly once.
+
+Each case runs in a fresh interpreter: module top-level code runs once per
+process and ovos_utils deduplicates repeat notices, so counting in-process
+would hide the very records under test. Notices reach stdout through the
+ovos_utils logger, so the count comes from there.
+"""
+
+import subprocess
+import sys
+import unittest
+
+
+def _deprecation_count(importer: str) -> int:
+    proc = subprocess.run([sys.executable, "-c", importer],
+                          capture_output=True, text=True)
+    assert proc.returncode == 0, f"import failed:\n{proc.stderr}"
+    return proc.stdout.count("Deprecation version=")
+
+
+class TestDeprecationNoise(unittest.TestCase):
+    def test_package_import_is_silent(self):
+        self.assertEqual(_deprecation_count("import ovos_plugin_manager"), 0)
+
+    def test_public_reexport_is_silent(self):
+        self.assertEqual(
+            _deprecation_count("from ovos_plugin_manager import OpenVoiceOSPlugin"),
+            0)
+
+    def test_solvers_import_is_silent(self):
+        self.assertEqual(
+            _deprecation_count("import ovos_plugin_manager.solvers"), 0)
+
+    def test_direct_deprecated_module_still_warns_once(self):
+        self.assertEqual(
+            _deprecation_count("import ovos_plugin_manager.installation"), 1)
+
+    def test_direct_deprecated_template_still_warns_once(self):
+        self.assertEqual(
+            _deprecation_count("import ovos_plugin_manager.templates.solvers"),
+            1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Merely `import ovos_plugin_manager` emitted deprecation notices about OPM's own internal modules. The package `__init__` imported `plugin_entry`, which imported `installation`, so every process that imports OPM logged notices whose `Caller=` was OPM itself — noise no downstream user can act on.

## Fix

A module-level deprecation notice is a message to external callers, so internal wiring must not trigger it.

- `__init__` re-exports `OpenVoiceOSPlugin` lazily via `__getattr__`, so plain `import ovos_plugin_manager` no longer loads the deprecated `plugin_entry`.
- `plugin_entry`, `installation`, and `templates.solvers` skip their notice when the import originates from within `ovos_plugin_manager` (small stack check in `_deprecation.py`). A direct import of any of these by an external caller still warns exactly once.
- `solvers` (the loader-function module, sibling of `stt`/`tts`) no longer carries a blanket notice of its own; the deprecation lives on `templates.solvers`, which it pulls the solver classes from and which still warns anyone importing those classes directly.

Public API is unchanged: `from ovos_plugin_manager import OpenVoiceOSPlugin` still works.

## Before / after (fresh interpreter, per import)

| import | before | after |
|---|---|---|
| `import ovos_plugin_manager` | 2 | 0 |
| `from ovos_plugin_manager import OpenVoiceOSPlugin` | 2 | 0 |
| `import ovos_plugin_manager.solvers` | 4 | 0 |
| `import ovos_plugin_manager.installation` | 1 | 1 |
| `import ovos_plugin_manager.templates.solvers` | 1 | 1 |

## Test

`test/unittests/test_deprecation_noise.py` imports each target in a fresh interpreter (module top-level runs once per process and ovos_utils dedups repeat notices, so isolation is required) and counts emitted notices.