### PR TITLE
feat: OVOS-TRANSFORM-1 conformance in shared transformer service bases

### DIFF
--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -39,6 +39,20 @@ from ovos_plugin_manager.text_transformers import find_utterance_transformer_plu
 from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
 
 
+def _stamp_provenance(context: dict, key: str, transformer_id: str) -> None:
+    """Stamp transformer self-identification per OVOS-TRANSFORM-1 §1.3.
+
+    On every touch a transformer performs, its own ``transformer_id`` MUST be
+    the last element of the corresponding ``<type>_transformer_ids`` list. The
+    orchestrator enforces this by appending the id once per execution window,
+    creating the list if absent.
+    """
+    ids = context.get(key)
+    if not isinstance(ids, list):
+        ids = []
+    context[key] = ids + [transformer_id]
+
+
 class TransformersService:
     """Base class for transformer pipeline runners.
 
@@ -227,11 +241,27 @@ class UtteranceTransformersService(TransformersService):
         context = context or {}
         for module in self.plugins:
             try:
-                utterances, data = module.transform(utterances, context)
+                result = module.transform(utterances, context)
+                # OVOS-TRANSFORM-1 §7: a wrong-shape return is treated the
+                # same as a raised exception -> log and proceed with the
+                # prior transformer's output unchanged.
+                if not (isinstance(result, (tuple, list)) and len(result) == 2):
+                    LOG.warning(f"{module.name} returned wrong shape "
+                                f"(expected (utterances, context)): {type(result)}; "
+                                f"ignoring its output")
+                    continue
+                new_utterances, data = result
+                if not isinstance(data, dict):
+                    LOG.warning(f"{module.name} returned non-dict context; "
+                                f"ignoring its output")
+                    continue
                 _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
                 LOG.debug(f"{module.name}: {_safe}")
                 canceled = self._check_cancellation(data, module)
                 context = merge_dict(context, data)
+                utterances = new_utterances
+                # OVOS-TRANSFORM-1 §1.3: stamp the transformer's self-identification
+                _stamp_provenance(context, "utterance_transformer_ids", module.name)
                 if canceled:
                     break
             except Exception as e:
@@ -250,10 +280,19 @@ class MetadataTransformersService(TransformersService):
         for module in self.plugins:
             try:
                 data = module.transform(context)
+                # OVOS-TRANSFORM-1 §7: reject wrong-shape returns; a metadata
+                # transformer's only output is a Message.context dict (§3.3).
+                if not isinstance(data, dict):
+                    LOG.warning(f"{module.name} returned wrong shape "
+                                f"(expected context dict): {type(data)}; "
+                                f"ignoring its output")
+                    continue
                 _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
                 LOG.debug(f"{module.name}: {_safe}")
                 canceled = self._check_cancellation(data, module)
                 context = merge_dict(context, data)
+                # OVOS-TRANSFORM-1 §1.3: stamp the transformer's self-identification
+                _stamp_provenance(context, "metadata_transformer_ids", module.name)
                 if canceled:
                     break
             except Exception as e:
@@ -270,7 +309,25 @@ class IntentTransformersService(TransformersService):
     def transform(self, intent: IntentHandlerMatch) -> IntentHandlerMatch:
         for module in self.plugins:
             try:
-                intent = module.transform(intent)
+                result = module.transform(intent)
+                # OVOS-TRANSFORM-1 §7 / §3.4: reject wrong-shape returns.
+                if not isinstance(result, IntentHandlerMatch):
+                    LOG.warning(f"{module.name} returned wrong shape "
+                                f"(expected IntentHandlerMatch): {type(result)}; "
+                                f"ignoring its output")
+                    continue
+                # OVOS-TRANSFORM-1 §3.4 identity invariant: an intent
+                # transformer MUST NOT change the dispatch identity
+                # (skill_id / match_type). If it does, discard the output
+                # and keep the prior Match — this is the orchestrator-side
+                # safety net for a MUST NOT the transformer already owes.
+                if (result.match_type != intent.match_type or
+                        result.skill_id != intent.skill_id):
+                    LOG.warning(f"{module.name} attempted to change intent "
+                                f"identity (match_type/skill_id); ignoring its "
+                                f"output per OVOS-TRANSFORM-1 §3.4")
+                    continue
+                intent = result
                 LOG.debug(f"{module.name}: {intent}")
             except Exception as e:
                 LOG.warning(f"{module.name} transform exception: {e}")

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -112,7 +112,8 @@ class TestPriorityOrdering(unittest.TestCase):
         self.assertEqual([p.name for p in service.plugins], ["first", "last"])
         utterances, context = service.transform(["hello"])
         self.assertEqual(utterances, ["last:first:hello"])
-        self.assertEqual(context, {"first": True, "last": True})
+        self.assertEqual(context, {"first": True, "last": True,
+                                   "utterance_transformer_ids": ["first", "last"]})
 
     def test_legacy_descending_low_priority_runs_last(self):
         service = self._service(sort_ascending=False)
@@ -293,7 +294,8 @@ class TestServiceTransforms(unittest.TestCase):
         service = self._empty(MetadataTransformersService)
         service.loaded_plugins["m"] = Meta("m")
         context = service.transform({"seed": 1})
-        self.assertEqual(context, {"seed": 1, "injected": True})
+        self.assertEqual(context, {"seed": 1, "injected": True,
+                                   "metadata_transformer_ids": ["m"]})
 
     def test_dialog_transform(self):
         class Dialog(DialogTransformer):
@@ -452,6 +454,149 @@ class TestTTSTransformersModule(unittest.TestCase):
             find_tts_transformer_plugins, load_tts_transformer_plugin)
         self.assertTrue(callable(find_tts_transformer_plugins))
         self.assertTrue(callable(load_tts_transformer_plugin))
+
+
+class TestTransform1Conformance(unittest.TestCase):
+    """OVOS-TRANSFORM-1 §1.3 provenance, §7 wrong-shape rejection and §3.4
+    intent dispatch-identity invariant."""
+
+    def _empty(self, klass, **kwargs):
+        with patch.object(klass, "plugin_finder", staticmethod(_fake_finder({}))):
+            return klass(config={}, **kwargs)
+
+    # §1.3 -- provenance stamping
+    def test_utterance_provenance_stamped_in_order(self):
+        p1 = _UttPrefixer("p1", priority=10)
+        p2 = _UttPrefixer("p2", priority=20)
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["p1"] = p1
+        service.loaded_plugins["p2"] = p2
+        _, context = service.transform(["hi"])
+        self.assertEqual(context.get("utterance_transformer_ids"), ["p1", "p2"])
+
+    def test_metadata_provenance_stamped_in_order(self):
+        class Meta(MetadataTransformer):
+            def transform(self, context=None):
+                return {}
+
+        p1 = Meta("p1", priority=10)
+        p2 = Meta("p2", priority=20)
+        service = self._empty(MetadataTransformersService)
+        service.loaded_plugins["p1"] = p1
+        service.loaded_plugins["p2"] = p2
+        context = service.transform({})
+        self.assertEqual(context.get("metadata_transformer_ids"), ["p1", "p2"])
+
+    # §7 -- wrong-shape returns rejected, prior output kept
+    def test_utterance_wrong_shape_rejected(self):
+        class Bad(UtteranceTransformer):
+            def transform(self, utterances, context=None):
+                return "not a tuple"
+
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["bad"] = Bad("bad", priority=10)
+        utterances, context = service.transform(["hello"], {"k": "v"})
+        self.assertEqual(utterances, ["hello"])
+        self.assertEqual(context, {"k": "v"})
+
+    def test_utterance_wrong_arity_rejected(self):
+        class Bad(UtteranceTransformer):
+            def transform(self, utterances, context=None):
+                return ["x"], {}, "extra"
+
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["bad"] = Bad("bad", priority=10)
+        utterances, _ = service.transform(["hello"], {})
+        self.assertEqual(utterances, ["hello"])
+
+    def test_utterance_non_dict_context_rejected(self):
+        class Bad(UtteranceTransformer):
+            def transform(self, utterances, context=None):
+                return ["x"], "not a dict"
+
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["bad"] = Bad("bad", priority=10)
+        utterances, context = service.transform(["hello"], {"k": "v"})
+        self.assertEqual(utterances, ["hello"])
+        self.assertEqual(context, {"k": "v"})
+
+    def test_metadata_wrong_shape_rejected(self):
+        class Bad(MetadataTransformer):
+            def transform(self, context=None):
+                return ["not", "a", "dict"]
+
+        service = self._empty(MetadataTransformersService)
+        service.loaded_plugins["bad"] = Bad("bad", priority=10)
+        context = service.transform({"k": "v"})
+        self.assertEqual(context, {"k": "v"})
+
+    def test_intent_wrong_shape_rejected(self):
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        from ovos_plugin_manager.templates.transformers import IntentTransformer
+
+        class Bad(IntentTransformer):
+            def transform(self, intent):
+                return {"not": "a match"}
+
+        original = IntentHandlerMatch(match_type="skillA:foo", match_data={},
+                                      skill_id="skillA", utterance="hello")
+        service = self._empty(IntentTransformersService)
+        service.loaded_plugins["bad"] = Bad("bad", priority=10)
+        result = service.transform(original)
+        self.assertEqual(result.match_type, "skillA:foo")
+
+    # §3.4 -- intent dispatch-identity invariant
+    def test_intent_identity_change_rejected(self):
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        from ovos_plugin_manager.templates.transformers import IntentTransformer
+
+        class Rogue(IntentTransformer):
+            def transform(self, intent):
+                return IntentHandlerMatch(match_type="skillB:bar", match_data={},
+                                          skill_id="skillB", utterance="hello")
+
+        original = IntentHandlerMatch(match_type="skillA:foo", match_data={},
+                                      skill_id="skillA", utterance="hello")
+        service = self._empty(IntentTransformersService)
+        service.loaded_plugins["rogue"] = Rogue("rogue", priority=50)
+        result = service.transform(original)
+        self.assertEqual(result.match_type, "skillA:foo")
+        self.assertEqual(result.skill_id, "skillA")
+
+    def test_intent_skill_id_change_rejected(self):
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        from ovos_plugin_manager.templates.transformers import IntentTransformer
+
+        class Rogue(IntentTransformer):
+            def transform(self, intent):
+                return IntentHandlerMatch(match_type="skillA:foo", match_data={},
+                                          skill_id="evil", utterance="hello")
+
+        original = IntentHandlerMatch(match_type="skillA:foo", match_data={},
+                                      skill_id="skillA", utterance="hello")
+        service = self._empty(IntentTransformersService)
+        service.loaded_plugins["rogue"] = Rogue("rogue", priority=50)
+        result = service.transform(original)
+        self.assertEqual(result.skill_id, "skillA")
+
+    def test_intent_identity_preserving_change_accepted(self):
+        """§3.4 permits enriching match_data while identity is unchanged."""
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        from ovos_plugin_manager.templates.transformers import IntentTransformer
+
+        class Enricher(IntentTransformer):
+            def transform(self, intent):
+                return IntentHandlerMatch(match_type=intent.match_type,
+                                          match_data={"slot": "value"},
+                                          skill_id=intent.skill_id,
+                                          utterance=intent.utterance)
+
+        original = IntentHandlerMatch(match_type="skillA:foo", match_data={},
+                                      skill_id="skillA", utterance="hello")
+        service = self._empty(IntentTransformersService)
+        service.loaded_plugins["e"] = Enricher("e", priority=50)
+        result = service.transform(original)
+        self.assertEqual(result.match_data.get("slot"), "value")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adopts three OVOS-TRANSFORM-1 conformance requirements into the shared
`UtteranceTransformersService` / `MetadataTransformersService` /
`IntentTransformersService` bases in `ovos_plugin_manager/transformer_services.py`:

- **§1.3 transformer self-identification.** Each transformer that touches a
  Message appends its own `transformer_id` as the last element of the
  corresponding `utterance_transformer_ids` / `metadata_transformer_ids`
  context list.
- **§7 wrong-shape rejection.** A transformer return of the wrong shape (wrong
  type/arity, non-dict context, non-`IntentHandlerMatch` intent) is treated
  the same as a raised exception: logged, its output discarded, and the chain
  proceeds with the prior transformer's output unchanged.
- **§3.4 intent dispatch-identity invariant.** An intent transformer's return
  MUST NOT change `Match.skill_id` / `Match.match_type` (the dispatch
  identity). The orchestrator enforces this as the §7 shape-violation safety
  net: a Match whose identity differs from its input is discarded and the
  prior Match is kept.

Priority-ascending ordering, the `order` config override, and §8.1
cancellation stamping (`cancel_by`) were already conformant in these bases
from earlier PRs (#410, #412) and are unchanged here.

Ported faithfully from `ovos-core#785`, which had locally reimplemented these
services (`ovos_core/transformers.py`) for conformance before dev refactored
them to subclass these shared bases. `ovos-core#785` will be reworked on top
of this PR to drop its local reimplementation in favor of the shared
conformant bases.

## Testing

- New tests in `test/unittests/test_transformer_services.py`
  (`TestTransform1Conformance`) cover provenance stamping, wrong-shape
  rejection for all three services, and both identity-invariant fields
  (`match_type`, `skill_id`) plus an identity-preserving enrichment case.
- Full unit suite: `1129 passed` locally, no regressions vs. clean `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
