### PR TITLE
feat: declare intent_context on IntentHandlerMatch

### DIFF
--- a/ovos_plugin_manager/templates/pipeline.py
+++ b/ovos_plugin_manager/templates/pipeline.py
@@ -23,6 +23,8 @@ class IntentHandlerMatch:
             A termination or continuation of an already-active skill's
             participation — e.g. a stop — sets this, since it must not register
             the target as a freshly activated skill.
+        intent_context (Optional[Dict]): Context keywords this match promotes
+            into the session's intent_context, per OVOS-CONTEXT-1 §5.1.
     """
     match_type: str
     match_data: Optional[Dict] = None
@@ -30,6 +32,7 @@ class IntentHandlerMatch:
     utterance: Optional[str] = None
     updated_session: Optional[Session] = None
     suppress_activation: bool = False
+    intent_context: Optional[Dict] = None
 
 
 class PipelinePlugin:


### PR DESCRIPTION
## Summary
- Add `intent_context: Optional[Dict] = None` to `IntentHandlerMatch` (templates/pipeline.py) so pipeline plugins can promote context keywords per OVOS-CONTEXT-1 §5.1 without downstream `getattr(match, "intent_context", None)` defensive coding.

## Test plan
- [x] `pytest test/unittests` (pre-existing unrelated failures only: `test_hardware.py::TestLed::*` — missing `ovos-hardware-helpers` extra)

🤖 Generated with Claude Code