### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,52 @@
-# OVOS plugin manager
+# OVOS Plugin Manager
 
-OPM can be used to load and create plugins for the OpenVoiceOS ecosystem!
+`ovos-plugin-manager` (OPM) is the plugin discovery, loading, and configuration framework for the OpenVoiceOS ecosystem. It defines the base classes that OVOS plugins implement, and it finds and loads installed plugins at runtime through Python entry points.
 
-![image](https://github.com/OpenVoiceOS/ovos-plugin-manager/assets/33701864/8c939267-42fc-4377-bcdb-f7df65e73252)
+![OPM architecture diagram](https://github.com/OpenVoiceOS/ovos-plugin-manager/assets/33701864/8c939267-42fc-4377-bcdb-f7df65e73252)
 
-Documentation can be found in the [ovos-technical-manual](https://openvoiceos.github.io/ovos-technical-manual/OPM)
+## Install
+
+```bash
+pip install ovos-plugin-manager
+```
+
+Media provider plugins need an extra dependency. Install it with:
+
+```bash
+pip install ovos-plugin-manager[media]
+```
+
+## Usage
+
+Find and load an installed STT plugin by its entry point name.
+
+```python
+from ovos_plugin_manager.stt import find_stt_plugins, load_stt_plugin
+
+plugins = find_stt_plugins()
+# {'ovos-stt-plugin-whisper': <class 'WhisperSTT'>, ...}
+
+MySTT = load_stt_plugin("ovos-stt-plugin-whisper")
+stt = MySTT(config={"lang": "en-US"})
+```
+
+Or create a plugin from the active configuration (`mycroft.conf` / `ovos.conf`).
+
+```python
+from ovos_plugin_manager.stt import OVOSSTTFactory
+
+stt = OVOSSTTFactory.create()
+```
+
+See [docs/index.md](docs/index.md) for the full guide, including TTS, wake word, VAD, and transformer plugins, and how to write a new plugin.
+
+## Related projects
+
+- [OpenVoiceOS/ovos-core](https://github.com/OpenVoiceOS/ovos-core): the OVOS voice assistant core, the main consumer of OPM
+- [OpenVoiceOS/ovos-audio](https://github.com/OpenVoiceOS/ovos-audio): loads TTS and audio playback plugins through OPM
+- [OpenVoiceOS/ovos-dinkum-listener](https://github.com/OpenVoiceOS/ovos-dinkum-listener): loads STT, wake word, and VAD plugins through OPM
+- [OpenVoiceOS/ovos-technical-manual](https://openvoiceos.github.io/ovos-technical-manual/OPM): the OVOS technical manual entry for OPM
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agent Plugins
 
-The agent plugin system extends OPM with composable NLP components for conversational AI, tool use, and text understanding. Plugins are discovered via Python entry points exactly like all other OPM plugin types.
+The agent plugin system extends OPM with composable NLP components for conversational AI, tool use, and text understanding. OPM discovers these plugins through Python entry points, the same way it discovers every other plugin type.
 
 Base classes: `ovos_plugin_manager/templates/agents.py`, `ovos_plugin_manager/templates/agent_tools.py`
 
@@ -10,35 +10,35 @@ Base classes: `ovos_plugin_manager/templates/agents.py`, `ovos_plugin_manager/te
 
 | Group | Base Class | Purpose |
 |---|---|---|
-| `opm.agents.chat` | `ChatEngine` | Multi-turn chat / agentic loops — `continue_chat(messages)` → `AgentMessage` |
+| `opm.agents.chat` | `ChatEngine` | Multi-turn chat and agentic loops, through `continue_chat(messages)` to `AgentMessage` |
 | `opm.agents.chat.multimodal` | `MultimodalChatEngine` | Chat with image/audio/file inputs |
 | `opm.agents.toolbox` | `ToolBox` | Groups of callable `AgentTool` functions exposed to agents via bus or direct call |
 | `opm.agents.summarizer` | `SummarizerEngine` / `ChatSummarizerEngine` | Document or chat-history summarisation |
 | `opm.agents.retrieval` | `RetrievalEngine` | Knowledge-base / vector-index query (`query(q, lang, k)` → `List[Tuple[str, float]]`) |
-| `opm.plugin.persona` | `dict` | Static persona config dict; consumed by `ovos-persona` to wire a ChatEngine with a system prompt |
+| `opm.plugin.persona` | `dict` | Static persona config dict, consumed by `ovos-persona` to wire a ChatEngine with a system prompt |
 
-`AgentContextManager` (`agents.py:35`) — optional companion base class for plugins that augment conversation context (RAG, memory, history trimming). Not a standalone entry point group; used inside `ChatEngine` implementations.
+`AgentContextManager` (`agents.py:35`) is an optional companion base class for plugins that augment conversation context (RAG, memory, history trimming). It is not a standalone entry point group. `ChatEngine` implementations use it internally.
 
 ---
 
 ## Available ToolBoxes (`opm.agents.toolbox`)
 
-Each `ToolBox` implements `discover_tools() → List[AgentTool]` (`agent_tools.py:314`). Tools are callable directly via `ToolBox.call_tool(name, kwargs)` or over the OVOS bus via the `ovos.persona.tools.{toolbox_id}.call` message topic (`agent_tools.py:102`).
+Each `ToolBox` implements `discover_tools() → List[AgentTool]` (`agent_tools.py:314`). You can call tools directly with `ToolBox.call_tool(name, kwargs)`, or over the OVOS bus with the `ovos.persona.tools.{toolbox_id}.call` message topic (`agent_tools.py:102`).
 
 | Plugin ID | Class | Tools | Package | API Key |
 |---|---|---|---|---|
-| `ovos-wikipedia-tools` | `WikipediaToolBox` | `search_wikipedia`, `get_wikipedia_sections`, `get_wikipedia_page` | `ovos-wikipedia-solver` | None — public Wikipedia REST API |
-| `ovos-ddg-tools` | `DuckDuckGoToolBox` | `search_duckduckgo`, `get_duckduckgo_infobox` | `ovos-ddg-solver-plugin` | None — DuckDuckGo Instant Answer API |
-| `ovos-wolfram-alpha-tools` | `WolframAlphaToolBox` | `compute`, `compute_full` | `ovos-wolfram-alpha-solver` | Optional — free key at developer.wolframalpha.com; demo key bundled |
-| `ovos-weather-tools` | `WeatherToolBox` | `get_current_weather`, `get_daily_forecast`, `get_hourly_forecast` | `ovos-skill-weather` | None — Open-Meteo public API |
-| `ovos-datetime-tools` | `DateTimeToolBox` | `get_current_datetime`, `convert_timezone`, `get_timezone_for_location` | `ovos-skill-date-time` | None — stdlib + pytz |
+| `ovos-wikipedia-tools` | `WikipediaToolBox` | `search_wikipedia`, `get_wikipedia_sections`, `get_wikipedia_page` | `ovos-wikipedia-solver` | None, public Wikipedia REST API |
+| `ovos-ddg-tools` | `DuckDuckGoToolBox` | `search_duckduckgo`, `get_duckduckgo_infobox` | `ovos-ddg-solver-plugin` | None, DuckDuckGo Instant Answer API |
+| `ovos-wolfram-alpha-tools` | `WolframAlphaToolBox` | `compute`, `compute_full` | `ovos-wolfram-alpha-solver` | Optional, free key at developer.wolframalpha.com, and a demo key ships in the plugin |
+| `ovos-weather-tools` | `WeatherToolBox` | `get_current_weather`, `get_daily_forecast`, `get_hourly_forecast` | `ovos-skill-weather` | None, Open-Meteo public API |
+| `ovos-datetime-tools` | `DateTimeToolBox` | `get_current_datetime`, `convert_timezone`, `get_timezone_for_location` | `ovos-skill-date-time` | None, stdlib + pytz |
 | `ovos-ip-tools` | `IPAddressToolBox` | `get_local_ip_addresses`, `get_public_ip` | `ovos-skill-ip` | None |
-| `ovos-iss-tools` | `ISSLocationToolBox` | `get_iss_position`, `get_iss_crew` | `ovos-skill-iss-location` | Optional — geonames.org user for reverse geocoding |
-| `ovos-speedtest-tools` | `SpeedTestToolBox` | `run_speedtest` | `ovos-skill-speedtest` | None — Speedtest.net |
-| `ovos-wallpapers-tools` | `WallpapersToolBox` | `search_wallpapers` | `ovos-skill-wallpapers` | None — wallhaven.cc public API |
-| `ovos-wikihow-tools` | `WikiHowToolBox` | `search_wikihow`, `get_wikihow_steps` | `ovos-skill-wikihow` | None — pywikihow scraper |
-| `ovos-wordnet-tools` | `WordNetToolBox` | `lookup_word`, `define_word` | `ovos-skill-wordnet` | None — local NLTK corpus |
-| `ovos-skill-md-toolbox` | `SkillMDToolBox` | dynamic — one tool per installed `SKILL.md` | `ovos-agentic-loop` | Requires a configured `ChatEngine` (brain) |
+| `ovos-iss-tools` | `ISSLocationToolBox` | `get_iss_position`, `get_iss_crew` | `ovos-skill-iss-location` | Optional, geonames.org user for reverse geocoding |
+| `ovos-speedtest-tools` | `SpeedTestToolBox` | `run_speedtest` | `ovos-skill-speedtest` | None, Speedtest.net |
+| `ovos-wallpapers-tools` | `WallpapersToolBox` | `search_wallpapers` | `ovos-skill-wallpapers` | None, wallhaven.cc public API |
+| `ovos-wikihow-tools` | `WikiHowToolBox` | `search_wikihow`, `get_wikihow_steps` | `ovos-skill-wikihow` | None, pywikihow scraper |
+| `ovos-wordnet-tools` | `WordNetToolBox` | `lookup_word`, `define_word` | `ovos-skill-wordnet` | None, local NLTK corpus |
+| `ovos-skill-md-toolbox` | `SkillMDToolBox` | dynamic: one tool per installed `SKILL.md` | `ovos-agentic-loop` | Requires a configured `ChatEngine` (brain) |
 | `ovos-filesystem-tools` | `FileSystemToolBox` | `read_file`, `write_file`, `list_directory`, `search_in_files`, `find_files` | `ovos-agentic-loop` | None |
 | `ovos-shell-tools` | `ShellToolBox` | `run_command` | `ovos-agentic-loop` | None |
 | `ovos-web-search-tools` | `WebSearchToolBox` | `web_search` | `ovos-agentic-loop` | None |
@@ -47,13 +47,13 @@ Each `ToolBox` implements `discover_tools() → List[AgentTool]` (`agent_tools.p
 ### Tool schema
 
 Each `AgentTool` (`agent_tools.py:40`) carries:
-- `name` — snake_case identifier used by the LLM
-- `description` — natural-language purpose shown to the LLM
-- `argument_schema` — Pydantic `ToolArguments` subclass; JSON Schema auto-generated for LLM tool-calling APIs
-- `output_schema` — Pydantic `ToolOutput` subclass; validated on every call
-- `tool_call` — the Python callable; receives an instantiated `ToolArguments`, returns `ToolOutput`
+- `name`: snake_case identifier the LLM uses
+- `description`: natural-language purpose shown to the LLM
+- `argument_schema`: Pydantic `ToolArguments` subclass. JSON Schema is auto-generated from it for LLM tool-calling APIs
+- `output_schema`: Pydantic `ToolOutput` subclass, validated on every call
+- `tool_call`: the Python callable. It receives an instantiated `ToolArguments` and returns `ToolOutput`
 
-`ToolBox.tool_json_list` (`agent_tools.py:290`) converts all tools to the JSON Schema list format expected by OpenAI / Anthropic / Gemini tool-calling endpoints.
+`ToolBox.tool_json_list` (`agent_tools.py:290`) converts all tools to the JSON Schema list format that OpenAI, Anthropic, and Gemini tool-calling endpoints expect.
 
 ---
 
@@ -108,32 +108,32 @@ def continue_chat(self, messages: List[AgentMessage],
 
 ### Tool calling
 
-A conversation can carry tool turns. `MessageRole.TOOL` is the role of a tool
-result, and `AgentMessage` carries optional tool fields:
+A conversation can carry tool turns. `MessageRole.TOOL` is the role of a tool result.
+`AgentMessage` carries optional tool fields:
 
-- `tool_calls: Optional[List[ToolCall]]` — set on an `ASSISTANT` message that
-  requests tool invocations (`ToolCall(id, name, arguments)`); `content` may be `""`.
-- `tool_call_id` / `name` — set on a `TOOL` message, identifying the `ToolCall` it
+- `tool_calls: Optional[List[ToolCall]]`: set on an `ASSISTANT` message that
+  requests tool invocations (`ToolCall(id, name, arguments)`). `content` may be `""`.
+- `tool_call_id` / `name`: set on a `TOOL` message, and identify the `ToolCall` it
   answers.
 
-`continue_chat` accepts an optional `tools` argument — pass `ToolBox` object(s)
-directly (preferred) and/or OpenAI tool dicts; the engine coerces it with
+`continue_chat` accepts an optional `tools` argument. Pass `ToolBox` object(s) directly
+(preferred), OpenAI tool dicts, or both. The engine coerces the argument with
 `ToolBox.normalize_tools(tools)` (see [`api/agent-tools.md`](api/agent-tools.md)).
-An engine that can use it sets the class attribute `supports_tools = True` and
+An engine that can use tools sets the class attribute `supports_tools = True`, and
 returns an assistant `AgentMessage` whose `tool_calls` are populated when the model
-requests them. Engines that don't support
-tools leave `supports_tools = False` and ignore the argument — the new kwarg is
-optional, so pre-existing 4-arg `continue_chat` overrides keep working unchanged.
-The ordering invariant providers expect: an assistant message carrying `tool_calls`
-must be followed by one `TOOL` message per `ToolCall.id`. The orchestration loop
-that drives this lives in `ovos-agentic-loop` (`NativeToolCallEngine`), not in the
-provider engines.
+requests them. An engine that does not support tools leaves `supports_tools = False`
+and ignores the argument. The kwarg is optional, so existing 4-arg `continue_chat`
+overrides keep working unchanged.
+
+Providers expect this ordering: an assistant message that carries `tool_calls` must be
+followed by one `TOOL` message per `ToolCall.id`. The orchestration loop that drives this
+lives in `ovos-agentic-loop` (`NativeToolCallEngine`), not in the provider engines.
 
 ---
 
 ## Available Personas (`opm.plugin.persona`)
 
-Each persona entry is a dict defining `chat_engine`, `system_prompt`, and optionally `toolboxes`. Loaded and wired by the `ovos-persona` service.
+Each persona entry is a dict that defines `chat_engine`, `system_prompt`, and optionally `toolboxes`. The `ovos-persona` service loads and wires each entry.
 
 | Persona ID | Backend | Package |
 |---|---|---|
@@ -187,7 +187,7 @@ class MyToolBox(ToolBox):
         )]
 ```
 
-`ToolBox.call_tool` validates input and output against the Pydantic schemas automatically (`agent_tools.py:195`). `discover_tools` is called once at init and again lazily if a tool is not found in the cache (`agent_tools.py:104`).
+`ToolBox.call_tool` validates input and output against the Pydantic schemas automatically (`agent_tools.py:195`). `discover_tools` runs once at init, and again lazily if a tool is not found in the cache (`agent_tools.py:104`).
 
 ---
 
@@ -230,4 +230,8 @@ Config is passed as a plain `dict` to `__init__`. OPM reads plugin config from t
 | `system_prompt` | `str` | `""` | System prompt for `AgentContextManager` plugins (`agents.py:61`) |
 | `context_ttl` | `int` | `120` | Seconds before coreference context is pruned (`agents.py:598`) |
 
-ToolBox-specific keys are documented in each plugin's module docstring.
+Each plugin's module docstring documents its ToolBox-specific keys.
+
+---
+
+[← Voice Cloning](voice-clone.md) · [Home](index.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,8 @@
 # Configuration Utilities
 
-`ovos_plugin_manager.utils.config` provides helpers for resolving plugin configuration
-from the global OVOS config (`ovos.conf` / `mycroft.conf`), filtering language-specific
-options, and sorting by priority.
+`ovos_plugin_manager.utils.config` has helpers to resolve plugin configuration from the
+global OVOS config (`ovos.conf` / `mycroft.conf`), filter language-specific options, and
+sort them by priority.
 
 ## `get_plugin_config`
 
@@ -14,11 +14,11 @@ def get_plugin_config(
 ) -> dict
 ```
 
-Resolve a merged configuration dict for a plugin. Configuration precedence (highest to lowest):
+Resolve a merged configuration dict for a plugin. Configuration precedence, highest to lowest:
 
-1. Module-specific block — `config[section][module]`
-2. Section-level defaults — `config[section]` (scalar keys only)
-3. Top-level `lang` — `config['lang']`
+1. Module-specific block: `config[section][module]`
+2. Section-level defaults: `config[section]` (scalar keys only)
+3. Top-level `lang`: `config['lang']`
 
 **Parameters**
 
@@ -28,8 +28,8 @@ Resolve a merged configuration dict for a plugin. Configuration precedence (high
 | `section` | `str` | Top-level config key for the plugin category (e.g. `"stt"`, `"tts"`, `"hotwords"`). |
 | `module` | `str` | Plugin entry point name to look up inside `config[section]`. If omitted, reads from `config[section]['module']`. |
 
-**Returns** `dict` — merged config containing at minimum `module` and `lang` keys (except for
-`hotwords`, `VAD`, `listener`, and `gui` sections).
+**Returns** `dict`: merged config with at least `module` and `lang` keys, except for the
+`hotwords`, `VAD`, `listener`, and `gui` sections.
 
 **Example**
 
@@ -52,7 +52,8 @@ def load_plugin_configs(
 ) -> Union[dict, list]
 ```
 
-Load language/variant configuration for a single plugin by calling its `.config` entry point.
+Load language and variant configuration for a single plugin by calling its `.config` entry
+point.
 
 **Parameters**
 
@@ -72,7 +73,7 @@ Load language/variant configuration for a single plugin by calling its `.config`
 def load_configs_for_plugin_type(plug_type: PluginTypes) -> dict
 ```
 
-Load configs for **all** installed plugins of the given type.
+Load configs for all installed plugins of the given type.
 
 **Returns** `{plugin_name: {lang: [configs]}}`.
 
@@ -120,8 +121,8 @@ Return a mapping of language code to list of plugin names that support that lang
 def sort_plugin_configs(configs: dict) -> dict
 ```
 
-Sort each plugin's config list by the `"priority"` key (lower = higher priority).
-Invalid/empty config lists are removed.
+Sort each plugin's config list by the `"priority"` key. Lower values mean higher priority.
+The function removes invalid or empty config lists.
 
 **Returns** `{plugin_name: [sorted_configs]}`.
 
@@ -137,18 +138,22 @@ def get_valid_plugin_configs(
 ) -> list
 ```
 
-Filter a single plugin's `{lang: [configs]}` dict to configs matching `lang`.
-When `include_dialects=True`, configs for closely related dialects are included with a
-+15 priority bonus.
+Filter a single plugin's `{lang: [configs]}` dict to configs that match `lang`.
+When `include_dialects=True`, the result also includes configs for closely related
+dialects, with a +15 priority bonus.
 
 ---
 
 ## Config priority
 
-Within a config list, entries are sorted by their `"priority"` key. Higher values are
-considered more preferred; factory methods iterate through the list from the end.
+Within a config list, entries are sorted by their `"priority"` key. Higher values mean a
+more preferred config. Factory methods iterate through the list from the end, so the
+highest-priority entry runs last.
 
-The default priority is `60`. A dialect match boosts priority by `+15` (to 75), making it
-more preferred than a generic language match with the default priority. Since factory
-methods iterate configs from the end (highest priority last), larger priority values win.
+The default priority is `60`. A dialect match adds `15` to reach `75`, so it wins over a
+generic language match at the default priority.
+
+---
+
+[← Writing a Plugin](writing-plugins.md) · [Home](index.md) · [Transformers →](transformers.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,32 +1,33 @@
 
 # OVOS Plugin Manager (OPM) Documentation
 
-`ovos-plugin-manager` (OPM) is the central plugin discovery, loading, and configuration
-framework for the OpenVoiceOS ecosystem. It defines the base classes (templates) that all
-OVOS plugins must implement, and provides factory methods and utilities for finding and
-loading installed plugins at runtime via Python entry points.
+`ovos-plugin-manager` (OPM) is the plugin discovery, loading, and configuration framework
+for the OpenVoiceOS ecosystem. It defines the base classes (templates) that OVOS plugins
+implement, and it has factory methods and utilities to find and load installed plugins at
+runtime through Python entry points.
 
 ## Contents
 
-- [Plugin Types & Entry Points](plugin-types.md) — full `PluginTypes` enum and `setup.py` entry point names
-- [Transformer Pipelines](transformers.md) — the six transformer chains, runner services, config, ordering and deployment surfaces
-- [Writing a Plugin](writing-plugins.md) — step-by-step guide with `setup.py` template
-- [Configuration Utilities](configuration.md) — `get_plugin_config`, language configs, sorting
-- [Installation Utilities](installation.md) — `pip_install`, `search_pip`
+- [Installation Utilities](installation.md): `pip_install`, `search_pip`
+- [Plugin Types & Entry Points](plugin-types.md): full `PluginTypes` enum and `setup.py` entry point names
+- [Writing a Plugin](writing-plugins.md): step-by-step guide with `setup.py` template
+- [Configuration Utilities](configuration.md): `get_plugin_config`, language configs, sorting
+- [Transformer Pipelines](transformers.md): the six transformer chains, runner services, config, ordering and deployment surfaces
+- [Voice Cloning Plugins](voice-clone.md): the `opm.vc` audio-to-audio voice conversion contract
+- [Agent Plugins](agents.md): all available ChatEngine, ToolBox, and Persona plugins with entry point registry
 - **API References**
-  - [STT](api/stt.md) — Speech-to-Text
-  - [TTS](api/tts.md) — Text-to-Speech
-  - [Wake Word](api/wake-word.md) — Hotword / Wake Word detection
-  - [VAD](api/vad.md) — Voice Activity Detection
-  - [Microphone](api/microphone.md) — Audio input sources
-  - [PHAL](api/phal.md) — Platform/Hardware Abstraction Layer
-  - [Transformers](api/transformers.md) — Audio, Utterance, Dialog, Metadata, TTS, Intent transformers
-  - [Agents & Solvers](api/agents.md) — NLP solver and agent engine plugins
-  - [Agent Tools](api/agent-tools.md) — ToolBox plugin API (`opm.agents.toolbox`)
-- [Agent Plugins](agents.md) — all available ChatEngine, ToolBox, and Persona plugins with entry point registry
-  - [Pipeline](api/pipeline.md) — Intent matching pipeline plugins
-  - [Media Provider](api/media-provider.md) — OCP catalog/search providers (`opm.media.provider`, OVOS-OCP-1)
-  - [Language](api/language.md) — Translation and language detection plugins
+  - [STT](api/stt.md): Speech-to-Text
+  - [TTS](api/tts.md): Text-to-Speech
+  - [Wake Word](api/wake-word.md): Hotword / Wake Word detection
+  - [VAD](api/vad.md): Voice Activity Detection
+  - [Microphone](api/microphone.md): Audio input sources
+  - [PHAL](api/phal.md): Platform/Hardware Abstraction Layer
+  - [Transformers](api/transformers.md): Audio, Utterance, Dialog, Metadata, TTS, Intent transformers
+  - [Agents & Solvers](api/agents.md): NLP solver and agent engine plugins
+  - [Agent Tools](api/agent-tools.md): ToolBox plugin API (`opm.agents.toolbox`)
+  - [Pipeline](api/pipeline.md): Intent matching pipeline plugins
+  - [Media Provider](api/media-provider.md): OCP catalog/search providers (`opm.media.provider`, OVOS-OCP-1)
+  - [Language](api/language.md): Translation and language detection plugins
 
 ## Architecture Overview
 
@@ -40,8 +41,8 @@ ovos-core / ovos-dinkum-listener / ovos-audio
 ```
 
 Plugins are Python packages that register themselves under a well-known entry point group
-(e.g. `opm.stt`). OPM calls `importlib.metadata.entry_points()` to discover installed
-plugins without any manual registration.
+(for example, `opm.stt`). OPM calls `importlib.metadata.entry_points()` to discover
+installed plugins without any manual registration.
 
 ## Quick Start
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # Installation Utilities
 
-`ovos_plugin_manager.installation` provides helpers for installing plugins at runtime via
-`pip` and for searching PyPI for OVOS-compatible packages.
+`ovos_plugin_manager.installation` has helpers to install plugins at runtime with `pip`,
+and to search PyPI for OVOS-compatible packages.
 
 ## `pip_install`
 
@@ -13,14 +13,14 @@ def pip_install(
 ) -> bool
 ```
 
-Install one or more Python packages using the current interpreter's `pip`. Packages are
-installed sequentially in the order given.
+Install one or more Python packages with the current interpreter's `pip`. The function
+installs packages in the order given.
 
-If the interpreter binary is not writable by the current user, `sudo -n pip install` is
-attempted automatically.
+If the current user cannot write to the interpreter binary, the function tries
+`sudo -n pip install` automatically.
 
-A named lock (`ovos_pip.lock`) serializes concurrent calls so that parallel plugin
-installers do not race.
+A named lock (`ovos_pip.lock`) serializes concurrent calls, so parallel plugin installers
+do not race each other.
 
 **Parameters**
 
@@ -55,7 +55,7 @@ def search_pip(
 ) -> Iterator[Tuple[str, str]]
 ```
 
-Search PyPI for packages matching `query` by scraping `pypi.org/search`.
+Search PyPI for packages that match `query`. The function scrapes `pypi.org/search`.
 
 **Parameters**
 
@@ -81,8 +81,7 @@ for name, desc in search_pip("ovos-tts-plugin", max_results=5):
 
 ## `OpenVoiceOSPlugin.install`
 
-The `OpenVoiceOSPlugin` class (see `ovos_plugin_manager.plugin_entry`) wraps `pip_install`
-for convenience:
+The `OpenVoiceOSPlugin` class (see `ovos_plugin_manager.plugin_entry`) wraps `pip_install`:
 
 ```python
 from ovos_plugin_manager.plugin_entry import OpenVoiceOSPlugin
@@ -91,17 +90,22 @@ p = OpenVoiceOSPlugin({"package_name": "ovos-stt-plugin-whisper"})
 p.install()  # calls pip_install(["ovos-stt-plugin-whisper"])
 ```
 
-If `package_name` is not set but a GitHub `url` is present, it installs via
+If `package_name` is not set but a GitHub `url` is present, the plugin installs with
 `pip install git+<url>`.
 
 ---
 
 ## `PipException`
 
-Raised by `pip_install` when a package fails to install.
+`pip_install` raises this error when a package fails to install.
 
 ```python
 from ovos_plugin_manager.exceptions import PipException
 ```
 
-Subclasses `RuntimeError`. The error message includes the pip exit code and stderr.
+`PipException` subclasses `RuntimeError`. The error message includes the pip exit code and
+stderr.
+
+---
+
+[Home](index.md) · [Plugin Types →](plugin-types.md)

--- a/docs/plugin-types.md
+++ b/docs/plugin-types.md
@@ -1,11 +1,13 @@
 # Plugin Types & Entry Points
 
-All OVOS plugins are discovered via Python package entry points. The `PluginTypes` enum
+OPM discovers all OVOS plugins through Python package entry points. The `PluginTypes` enum
 in `ovos_plugin_manager.utils` maps plugin categories to their canonical entry point group
-names. A matching `PluginConfigTypes` enum provides `.config` sub-group names used when
-plugins expose supported-language configuration.
+names. A matching `PluginConfigTypes` enum has the `.config` sub-group names that plugins
+use to expose supported-language configuration.
 
 ## PluginTypes Enum
+
+### Speech and audio
 
 | Enum value | Entry point group | Template base class |
 |---|---|---|
@@ -13,60 +15,117 @@ plugins expose supported-language configuration.
 | `TTS` | `opm.tts` | `TTS` |
 | `WAKEWORD` | `opm.wake_word` | `HotWordEngine` |
 | `WAKEWORD_VERIFIER` | `opm.wake_word.verifier` | `HotWordVerifier` |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `VAD` | `opm.VAD` | `VADEngine` |
 | `MIC` | `opm.microphone` | `OVOSMicrophone` |
+
+### Hardware, skills, and the pipeline
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `PHAL` | `opm.phal` | `PHALPlugin` |
 | `ADMIN` | `opm.phal.admin` | `AdminPlugin` |
-| `SKILL` | `opm.skill` | — |
-| `GUI` | `opm.gui` | — |
-| `GUI_ADAPTER` | `opm.gui_adapter` | — |
+| `SKILL` | `opm.skill` | N/A |
+| `GUI` | `opm.gui` | N/A |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
+| `GUI_ADAPTER` | `opm.gui_adapter` | N/A |
 | `PIPELINE` | `opm.pipeline` | `PipelinePlugin` |
+
+### Language and transformers
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `TRANSLATE` | `opm.lang.translate` | `LanguageTranslator` |
 | `LANG_DETECT` | `opm.lang.detect` | `LanguageDetector` |
 | `UTTERANCE_TRANSFORMER` | `opm.transformer.text` | `UtteranceTransformer` |
 | `METADATA_TRANSFORMER` | `opm.transformer.metadata` | `MetadataTransformer` |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `AUDIO_TRANSFORMER` | `opm.transformer.audio` | `AudioTransformer` |
 | `DIALOG_TRANSFORMER` | `opm.transformer.dialog` | `DialogTransformer` |
 | `TTS_TRANSFORMER` | `opm.transformer.tts` | `TTSTransformer` |
 | `INTENT_TRANSFORMER` | `opm.transformer.intent` | `IntentTransformer` |
+
+### Phonemes, voice, and text processing
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `PHONEME` | `opm.g2p` | `Grapheme2PhonemePlugin` |
 | `AUDIO2IPA` | `opm.audio2ipa` | `Audio2IPAPlugin` |
 | `VOICE_CLONE` | `opm.vc` | `VoiceClonePlugin` |
 | `KEYWORD_EXTRACTION` | `opm.keywords` | `KeywordExtractor` |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `UTTERANCE_SEGMENTATION` | `opm.segmentation` | `UtteranceSegmenter` |
 | `TOKENIZATION` | `opm.tokenization` | `Tokenizer` |
 | `POSTAG` | `opm.postag` | `PosTagger` |
-| `EMBEDDINGS` | `opm.embeddings` | — |
-| `TEXT_EMBEDDINGS` | `opm.embeddings.text` | — |
-| `VOICE_EMBEDDINGS` | `opm.embeddings.voice` | — |
-| `IMAGE_EMBEDDINGS` | `opm.embeddings.image` | — |
-| `FACE_EMBEDDINGS` | `opm.embeddings.face` | — |
-| `TRIPLES` | `opm.triples` | — |
-| `STREAM_EXTRACTOR` | `opm.ocp.extractor` | — |
+
+### Embeddings and knowledge
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
+| `EMBEDDINGS` | `opm.embeddings` | N/A |
+| `TEXT_EMBEDDINGS` | `opm.embeddings.text` | N/A |
+| `VOICE_EMBEDDINGS` | `opm.embeddings.voice` | N/A |
+| `IMAGE_EMBEDDINGS` | `opm.embeddings.image` | N/A |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
+| `FACE_EMBEDDINGS` | `opm.embeddings.face` | N/A |
+| `TRIPLES` | `opm.triples` | N/A |
+
+### Media
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
+| `STREAM_EXTRACTOR` | `opm.ocp.extractor` | N/A |
 | `MEDIA_PROVIDER` | `opm.media.provider` | `MediaProvider` |
-| `AUDIO_PLAYER` | `opm.media.audio` | — |
-| `VIDEO_PLAYER` | `opm.media.video` | — |
-| `WEB_PLAYER` | `opm.media.web` | — |
-| `PERSONA` | `opm.plugin.persona` | — |
+| `AUDIO_PLAYER` | `opm.media.audio` | N/A |
+| `VIDEO_PLAYER` | `opm.media.video` | N/A |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
+| `WEB_PLAYER` | `opm.media.web` | N/A |
+
+### Agents
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
+| `PERSONA` | `opm.plugin.persona` | N/A |
 | `AGENT_MEMORY` | `opm.agents.memory` | `AgentContextManager` |
 | `AGENT_CHAT` | `opm.agents.chat` | `ChatEngine` |
-| `AGENT_CHAT_MULTIMODAL` | `opm.agents.chat.multimodal` | — |
+| `AGENT_CHAT_MULTIMODAL` | `opm.agents.chat.multimodal` | N/A |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `AGENT_RETRIEVAL` | `opm.agents.retrieval` | `RetrievalEngine` |
 | `AGENT_DOC_RETRIEVAL` | `opm.agents.retrieval.documents` | `DocumentIndexerEngine` |
 | `AGENT_QA_RETRIEVAL` | `opm.agents.retrieval.qa` | `QAIndexerEngine` |
 | `AGENT_RERANKER` | `opm.agents.reranker` | `ReRankerEngine` |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
 | `AGENT_SUMMARIZER` | `opm.agents.summarizer` | `SummarizerEngine` |
-| `AGENT_CHAT_SUMMARIZER` | `opm.agents.summarizer.chat` | — |
+| `AGENT_CHAT_SUMMARIZER` | `opm.agents.summarizer.chat` | N/A |
 | `AGENT_EXTRACTIVE_QA` | `opm.agents.extractive_qa` | `ExtractiveQAEngine` |
 | `AGENT_NLI` | `opm.agents.nli` | `NaturalLanguageInferenceEngine` |
-| `AGENT_COREF` | `opm.agents.coref` | — |
-| `AGENT_YES_NO` | `opm.agents.yesno` | — |
-| `AGENT_MULTIMODAL_ADAPTER` | `opm.agents.multimodal_adapter` | — |
+
+| Enum value | Entry point group | Template base class |
+|---|---|---|
+| `AGENT_COREF` | `opm.agents.coref` | N/A |
+| `AGENT_YES_NO` | `opm.agents.yesno` | N/A |
+| `AGENT_MULTIMODAL_ADAPTER` | `opm.agents.multimodal_adapter` | N/A |
 | `AGENT_TOOLBOX` | `opm.agents.toolbox` | `ToolBox` |
 
-### Deprecated Solver Types
+### Deprecated solver types
 
-These are superseded by the `AGENT_*` types above and will be removed in the next major release.
+The `AGENT_*` types above replace these. They will be removed in the next major release.
 
 | Enum value | Entry point group |
 |---|---|
@@ -74,14 +133,17 @@ These are superseded by the `AGENT_*` types above and will be removed in the nex
 | `CHAT_SOLVER` | `opm.solver.chat` |
 | `TLDR_SOLVER` | `opm.solver.summarization` |
 | `ENTAILMENT_SOLVER` | `opm.solver.entailment` |
+
+| Enum value | Entry point group |
+|---|---|
 | `MULTIPLE_CHOICE_SOLVER` | `opm.solver.multiple_choice` |
 | `READING_COMPREHENSION_SOLVER` | `opm.solver.reading_comprehension` |
 | `COREFERENCE_SOLVER` | `opm.coreference` |
 
 ## Legacy / Deprecated Entry Points
 
-These old entry point names are still recognized by OPM (mapped internally to their
-canonical equivalents) but should not be used in new plugins.
+OPM still recognizes these old entry point names and maps them internally to their
+canonical equivalents. Do not use them in new plugins.
 
 | Old name | Canonical name |
 |---|---|
@@ -89,22 +151,41 @@ canonical equivalents) but should not be used in new plugins.
 | `mycroft.plugin.tts` | `opm.tts` |
 | `mycroft.plugin.wake_word` | `opm.wake_word` |
 | `ovos.plugin.phal` | `opm.phal` |
+
+| Old name | Canonical name |
+|---|---|
 | `ovos.plugin.phal.admin` | `opm.phal.admin` |
 | `ovos.plugin.VAD` | `opm.vad` |
 | `ovos.plugin.microphone` | `opm.microphone` |
 | `ovos.plugin.skill` | `opm.skill` |
+
+| Old name | Canonical name |
+|---|---|
 | `ovos.plugin.gui` | `opm.gui` |
 | `ovos.plugin.g2p` | `opm.g2p` |
 | `ovos.plugin.audio2ipa` | `opm.audio2ipa` |
 | `neon.plugin.lang.translate` | `opm.lang.translate` |
+
+| Old name | Canonical name |
+|---|---|
 | `neon.plugin.lang.detect` | `opm.lang.detect` |
 | `neon.plugin.text` | `opm.transformer.text` |
 | `neon.plugin.metadata` | `opm.transformer.metadata` |
 | `neon.plugin.audio` | `opm.transformer.audio` |
+
+| Old name | Canonical name |
+|---|---|
 | `neon.plugin.solver` | `opm.solver.question` |
 | `intentbox.coreference` | `opm.coreference` |
 | `intentbox.keywords` | `opm.keywords` |
 | `intentbox.segmentation` | `opm.segmentation` |
+
+| Old name | Canonical name |
+|---|---|
 | `intentbox.tokenization` | `opm.tokenization` |
 | `intentbox.postag` | `opm.postag` |
 | `ovos.ocp.extractor` | `opm.ocp.extractor` |
+
+---
+
+[← Installation](installation.md) · [Home](index.md) · [Writing a Plugin →](writing-plugins.md)

--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -1,15 +1,15 @@
 # Transformer Pipelines
 
-Transformers are ordered black-box chains that rewrite an artifact at a
-fixed point in the voice pipeline: raw audio before STT, utterances after
-STT, message context before intent matching, the selected intent before
-dispatch, dialog text before TTS, and synthesized audio before playback.
+Transformers are ordered chains that rewrite an artifact at a fixed point in the voice
+pipeline: raw audio before STT, utterances after STT, message context before intent
+matching, the selected intent before dispatch, dialog text before TTS, and synthesized
+audio before playback.
 
-`ovos_plugin_manager.transformer_services` provides the canonical runner
-services that load, order and chain transformer plugins. They are consumed
-by ovos-core, ovos-audio, ovos-dinkum-listener, ovos-tts-server,
-ovos-stt-server, hivemind-core, hivemind-audio-binary-protocol and the
-HiveMind satellites — the same plugin works unmodified in all of them.
+`ovos_plugin_manager.transformer_services` has the canonical runner services that load,
+order, and chain transformer plugins. ovos-core, ovos-audio, ovos-dinkum-listener,
+ovos-tts-server, ovos-stt-server, hivemind-core, hivemind-audio-binary-protocol, and the
+HiveMind satellites all use these services, so the same plugin works unmodified in each of
+them.
 
 ## The six chains
 
@@ -24,9 +24,9 @@ HiveMind satellites — the same plugin works unmodified in all of them.
 
 ## Configuration
 
-Loading is **config-gated and opt-in**: a plugin only loads when its name
-appears in the chain's config section, and an entry can be disabled with
-`"active": false` without removing its config.
+Loading is config-gated and opt-in. A plugin loads only when its name appears in the
+chain's config section. You can disable an entry with `"active": false` without removing
+its config.
 
 ```json
 {
@@ -45,12 +45,12 @@ appears in the chain's config section, and an entry can be disabled with
 
 ### Ordering
 
-Chains run in **ascending priority order** (OVOS-TRANSFORM §4): a plugin
-with `priority = 1` runs before one with `priority = 50`. The default is
-50. Later plugins see — and may override — earlier plugins' output.
+Chains run in ascending priority order (OVOS-TRANSFORM §4): a plugin with `priority = 1`
+runs before one with `priority = 50`. The default is 50. A later plugin sees, and may
+override, an earlier plugin's output.
 
-A deployer can bypass priorities entirely with an explicit `order` list;
-loaded plugins absent from the list do not run:
+A deployer can bypass priorities entirely with an explicit `order` list. A loaded plugin
+that is absent from the list does not run:
 
 ```json
 {
@@ -62,23 +62,21 @@ loaded plugins absent from the list do not run:
 
 ### Cancellation
 
-A transformer can cancel the whole lifecycle (OVOS-TRANSFORM §8.1) by
-returning both `"canceled": true` and a `"cancel_reason"` in its context.
-The runner stamps `cancel_by` with the emitting plugin's name and stops the
-chain; the consumer terminates the lifecycle (e.g. ovos-core emits
-`ovos.utterance.cancelled` → `ovos.utterance.handled`). This is how
-stop-word plugins like `ovos-utterance-plugin-cancel` work.
+A transformer can cancel the whole lifecycle (OVOS-TRANSFORM §8.1) by returning both
+`"canceled": true` and a `"cancel_reason"` in its context. The runner stamps `cancel_by`
+with the emitting plugin's name and stops the chain. The consumer then ends the lifecycle
+(for example, ovos-core emits `ovos.utterance.cancelled`, then `ovos.utterance.handled`).
+Stop-word plugins such as `ovos-utterance-plugin-cancel` use this mechanism.
 
 ### Error handling
 
-A plugin exception never aborts the chain: it is logged and the chain
-proceeds with the previous plugin's output.
+A plugin exception never stops the chain. The runner logs the exception and the chain
+continues with the previous plugin's output.
 
 ## Where chains run — and surprise interactions
 
-The same chain type can run in more than one process. That is a feature —
-but each plugin should be enabled in **exactly one** place per deployment,
-or its effect is applied twice.
+The same chain type can run in more than one process. That is by design, but enable each
+plugin in exactly one place per deployment. Otherwise its effect applies twice.
 
 | Surface | Chains it can run |
 |---|---|
@@ -91,20 +89,19 @@ or its effect is applied twice.
 | hivemind-audio-binary-protocol | audio, utterance, metadata, dialog, tts |
 | HiveMind satellites (on device) | audio (pre-send), utterance (relay), tts (pre-playback) |
 
-Moving a chain **to a server is a deliberate centralization tool**: enable a
-dialog transformer on ovos-tts-server and every device that synthesizes
-through it gets the same tone/persona rewrite globally — the server then
-returns audio for *different text than you sent*, which looks surprising
-from the client but is exactly the point. The same applies to a shared STT
-server correcting transcripts for every client, or a HiveMind server
-canceling utterances by policy for the whole mesh.
+Moving a chain to a server is a deliberate way to centralize behavior. Enable a dialog
+transformer on ovos-tts-server, and every device that synthesizes through it gets the same
+tone or persona rewrite. The server then returns audio for different text than the client
+sent. This looks surprising from the client, but it is the intended effect. The same
+applies to a shared STT server that corrects transcripts for every client, or a HiveMind
+server that cancels utterances by policy for the whole mesh.
 
-Rules of thumb:
+Guidelines:
 
-- **Per-device effects** (denoise for one bad microphone, a voice effect on
-  one speaker) → enable on the device/satellite.
-- **Fleet-wide effects** (a global persona/tone, shared transcript
-  corrections, policy stop-words) → enable on the server everyone uses.
+- For a per-device effect (denoise for one bad microphone, a voice effect on one speaker),
+  enable the plugin on the device or satellite.
+- For a fleet-wide effect (a global persona or tone, shared transcript corrections, policy
+  stop-words), enable the plugin on the server everyone uses.
 - Never enable the same plugin on both sides of a connection.
 
 ## Consuming the runners
@@ -119,6 +116,10 @@ utterances, context = service.transform(["hello world"], {"lang": "en-US"})
 service.shutdown()
 ```
 
-All runners accept an optional bus (bound to plugins that support it, or
-later via `set_bus()`) and expose `plugins` (execution order),
-`get_available_plugins()`, `transform(...)` and `shutdown()`.
+All runners accept an optional bus, which they bind to plugins that support it, or you can
+bind it later with `set_bus()`. Each runner exposes `plugins` (execution order),
+`get_available_plugins()`, `transform(...)`, and `shutdown()`.
+
+---
+
+[← Configuration](configuration.md) · [Home](index.md) · [Voice Cloning →](voice-clone.md)

--- a/docs/voice-clone.md
+++ b/docs/voice-clone.md
@@ -1,13 +1,13 @@
 # Voice Cloning Plugins (`opm.vc`)
 
-Voice-cloning plugins perform **audio-to-audio** voice conversion: given a source
-speech file and a short reference speaker sample, the plugin outputs new audio that
-carries the linguistic content of the source but sounds like the reference speaker.
+Voice-cloning plugins perform audio-to-audio voice conversion. Given a source speech file
+and a short reference speaker sample, the plugin outputs new audio that carries the
+linguistic content of the source but sounds like the reference speaker.
 
-> **Scope boundary — text input is out of scope.**  Voice cloning from text (zero-shot
-> TTS with a speaker reference) belongs in TTS plugins and is configured via the TTS
-> plugin's own `config` section.  The `opm.vc` family deals exclusively with
-> already-recorded speech as input; it never receives raw text.
+> **Scope boundary: text input is out of scope.** Voice cloning from text (zero-shot TTS
+> with a speaker reference) belongs in TTS plugins, and you configure it through the TTS
+> plugin's own `config` section. The `opm.vc` family takes only already-recorded speech as
+> input. It never receives raw text.
 
 ---
 
@@ -24,8 +24,8 @@ Config section: `voice_clone`
 | `sample_rate → int` | Output sample rate in Hz (default 24000). Override to advertise the engine's native rate. |
 | `available_languages → List[str]` | BCP-47 tags supported. Return `[]` for language-agnostic engines (default). |
 
-`__init__(self, config=None)` stores the plugin-specific config dict; no further
-initialisation is mandated.
+`__init__(self, config=None)` stores the plugin-specific config dict. No other
+initialization step is required.
 
 ---
 
@@ -75,5 +75,9 @@ out_wav = cloner.clone_voice("/path/source.wav", "/path/reference.wav")
 
 ## Implementations
 
-Implementations register under the `opm.vc` entry-point group and are
-discovered with `find_voice_clone_plugins()`.
+Implementations register under the `opm.vc` entry-point group. Find them with
+`find_voice_clone_plugins()`.
+
+---
+
+[← Transformers](transformers.md) · [Home](index.md) · [Agent Plugins →](agents.md)

--- a/docs/writing-plugins.md
+++ b/docs/writing-plugins.md
@@ -1,10 +1,10 @@
 # Writing an OVOS Plugin
 
-This guide shows how to package a new OVOS plugin from scratch using `setup.py`.
+This guide shows how to package a new OVOS plugin from scratch with `setup.py`.
 
 ## 1. Implement the base class
 
-Choose the appropriate template from `ovos_plugin_manager.templates.*` and subclass it.
+Choose the matching template from `ovos_plugin_manager.templates.*` and subclass it.
 
 ### Example: STT plugin
 
@@ -84,7 +84,7 @@ class MyWakeWord(HotWordEngine):
 
 ## 2. Expose the plugin via `setup.py`
 
-Register your class under the correct entry point group so OPM can discover it.
+Register your class under the correct entry point group. This lets OPM discover it.
 
 ```python
 # setup.py
@@ -120,7 +120,7 @@ See [Plugin Types](plugin-types.md) for the full list.
 pip install -e .
 ```
 
-The plugin is now discoverable by OPM without any additional registration:
+OPM can now discover the plugin without any other registration step:
 
 ```python
 from ovos_plugin_manager.stt import find_stt_plugins, load_stt_plugin
@@ -130,9 +130,9 @@ MySTT = load_stt_plugin("my-engine-stt")
 
 ## 4. Expose language configurations (optional)
 
-Plugins that support multiple voices/languages/models should expose a `.config` entry
-point returning a dict of `{lang: [list_of_config_dicts]}`. Each config dict represents
-one voice/model variant and can include:
+A plugin that supports multiple voices, languages, or models should expose a `.config`
+entry point that returns a dict of `{lang: [list_of_config_dicts]}`. Each config dict
+represents one voice or model variant, and can include:
 
 | Key | Type | Description |
 |---|---|---|
@@ -162,7 +162,7 @@ class MyTTSPluginConfig:
 ## 5. `RuntimeRequirements`
 
 Override `runtime_requirements` to declare connectivity needs. OVOS uses this to decide
-whether the plugin can be loaded before network/internet is available.
+whether it can load the plugin before the network or internet is available.
 
 ```python
 from ovos_utils.process_utils import RuntimeRequirements
@@ -182,7 +182,7 @@ class MySTTPlugin(STT):
         )
 ```
 
-For a fully offline plugin, all values are `False` / `True` as appropriate.
+For a fully offline plugin, set each value to `False` or `True` as appropriate.
 
 ## 6. PHAL plugins
 
@@ -209,3 +209,7 @@ class MyPHALPlugin(PHALPlugin):
 # setup.py entry_points
 "opm.phal": ["my-phal-plugin = my_phal:MyPHALPlugin"]
 ```
+
+---
+
+[← Plugin Types](plugin-types.md) · [Home](index.md) · [Configuration →](configuration.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md in Simplified Technical English for clarity: shorter sentences, active voice, no marketing language. Adds an install/usage example and related-project links to the README, which previously only pointed to the external manual. Adds the standard footer navigation between docs pages and splits the large plugin-types.md reference tables into smaller, topic-grouped tables for readability.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with installation guidance, plugin discovery, configuration, related projects, and licensing information.
  * Clarified agent tools, plugin entry points, configuration precedence, priority rules, and installation behavior.
  * Improved documentation navigation and added references for transformers, voice cloning, agents, and language APIs.
  * Clarified transformer pipelines, cancellation, error handling, deployment, and voice-cloning input requirements.
  * Updated plugin-writing guidance and documented plugin types, deprecations, and legacy mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->