### PR TITLE
feat: one way to construct a ToolBox that every plugin survives

### DIFF
--- a/ovos_plugin_manager/persona.py
+++ b/ovos_plugin_manager/persona.py
@@ -1,7 +1,9 @@
-from typing import Type, Dict, Any
+import inspect
+from typing import Type, Dict, Any, Optional, List, Union
 
 from ovos_plugin_manager.templates.agent_tools import ToolBox
 from ovos_plugin_manager.utils import PluginTypes
+from ovos_utils.log import LOG
 
 
 def find_persona_plugins() -> Dict[str, Dict[str, Any]]:
@@ -21,3 +23,98 @@ def find_toolbox_plugins() -> Dict[str, Type[ToolBox]]:
     """
     from ovos_plugin_manager.utils import find_plugins
     return find_plugins(PluginTypes.AGENT_TOOLBOX)
+
+
+def load_toolbox_plugin(toolbox_id: str,
+                        config: Optional[Dict[str, Any]] = None,
+                        bus=None) -> Optional[ToolBox]:
+    """
+    Instantiate one installed ToolBox plugin by its entry-point name.
+
+    The base class takes ``(toolbox_id, config=None, bus=None)``, but plugins
+    conventionally hide the id and expose only ``(config=None)``, passing
+    their own id up. Callers that guess wrong get a TypeError, so this
+    inspects the subclass and passes only what it accepts, then fills in
+    ``toolbox_id`` and binds the bus afterwards.
+
+    @param toolbox_id: entry-point name of the toolbox
+    @param config: plugin-specific config, passed through if accepted
+    @param bus: messagebus client to bind, if the plugin did not bind one
+    @return: the ToolBox instance, or None if it is not installed or failed
+    """
+    plugins = find_toolbox_plugins()
+    clazz = plugins.get(toolbox_id)
+    if clazz is None:
+        LOG.warning(f"ToolBox plugin not installed: {toolbox_id}")
+        return None
+    try:
+        return init_toolbox(clazz, toolbox_id, config=config, bus=bus)
+    except Exception:
+        LOG.exception(f"Failed to load ToolBox plugin: {toolbox_id}")
+        return None
+
+
+def load_toolbox_plugins(toolbox_ids: Optional[List[str]] = None,
+                         config: Optional[Dict[str, Any]] = None,
+                         bus=None) -> List[ToolBox]:
+    """
+    Instantiate several ToolBox plugins, skipping any that fail.
+
+    @param toolbox_ids: entry-point names to load, or None for all installed
+    @param config: mapping of toolbox_id to that plugin's config
+    @param bus: messagebus client to bind to each toolbox
+    @return: list of successfully loaded ToolBox instances
+    """
+    config = config or {}
+    if toolbox_ids is None:
+        toolbox_ids = list(find_toolbox_plugins())
+    toolboxes = []
+    for tid in toolbox_ids:
+        tb = load_toolbox_plugin(tid, config=config.get(tid, {}), bus=bus)
+        if tb is not None:
+            toolboxes.append(tb)
+    return toolboxes
+
+
+def init_toolbox(clazz: Type[ToolBox], toolbox_id: str,
+                 config: Optional[Dict[str, Any]] = None,
+                 bus=None) -> ToolBox:
+    """
+    Construct a ToolBox subclass without assuming its __init__ signature.
+
+    Every loader in the ecosystem called this differently — one passed
+    ``toolbox_id`` alone, others passed ``config`` and ``bus`` — and every
+    shipped plugin rejected at least one of those shapes. Rather than force a
+    signature on plugins that already exist, pass each keyword only if the
+    subclass declares it (or accepts ``**kwargs``), then set what was skipped.
+
+    @param clazz: the ToolBox subclass
+    @param toolbox_id: entry-point name, used if the plugin does not set one
+    @param config: plugin-specific config
+    @param bus: messagebus client to bind, if the plugin did not bind one
+    @return: the constructed ToolBox
+    """
+    try:
+        params = inspect.signature(clazz.__init__).parameters
+    except (TypeError, ValueError):  # builtins / C extensions
+        params = {}
+    takes_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD
+                       for p in params.values())
+
+    kwargs = {}
+    for name, value in (("toolbox_id", toolbox_id), ("config", config),
+                        ("bus", bus)):
+        if value is None and name != "toolbox_id":
+            continue
+        if name in params or takes_kwargs:
+            kwargs[name] = value
+
+    toolbox = clazz(**kwargs)
+
+    # a plugin that hides toolbox_id sets its own, usually as a class
+    # attribute; only fill in the entry-point name when it did not
+    if not getattr(toolbox, "toolbox_id", None):
+        toolbox.toolbox_id = toolbox_id
+    if bus is not None and getattr(toolbox, "bus", None) is None:
+        toolbox.bind(bus)
+    return toolbox

--- a/test/unittests/test_persona.py
+++ b/test/unittests/test_persona.py
@@ -1,7 +1,41 @@
 import unittest
+from typing import List
 from unittest.mock import patch
 
+from ovos_plugin_manager.templates.agent_tools import ToolBox
 from ovos_plugin_manager.utils import PluginTypes
+
+
+class _HidesId(ToolBox):
+    """The shape every shipped toolbox uses: id is the plugin's own business."""
+    toolbox_id = "hides-id"
+
+    def __init__(self, config=None):
+        super().__init__(toolbox_id=self.toolbox_id, config=config)
+
+    def discover_tools(self) -> List:
+        return []
+
+
+class _TakesIdAndBus(ToolBox):
+    """The base-class shape, spelled out in full."""
+
+    def __init__(self, toolbox_id, config=None, bus=None):
+        super().__init__(toolbox_id, config=config, bus=bus)
+
+    def discover_tools(self) -> List:
+        return []
+
+
+class _TakesKwargs(ToolBox):
+    """A plugin that forwards whatever it is given."""
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("toolbox_id", "takes-kwargs")
+        super().__init__(**kwargs)
+
+    def discover_tools(self) -> List:
+        return []
 
 
 class TestPersona(unittest.TestCase):
@@ -15,3 +49,70 @@ class TestPersona(unittest.TestCase):
         from ovos_plugin_manager.persona import find_persona_plugins
         find_persona_plugins()
         find_plugins.assert_called_once_with(self.PLUGIN_TYPE)
+
+
+class TestInitToolbox(unittest.TestCase):
+    """init_toolbox must construct every signature plugins use in the wild."""
+
+    def test_constructs_all_shapes(self):
+        from ovos_plugin_manager.persona import init_toolbox
+        for clazz in (_HidesId, _TakesIdAndBus, _TakesKwargs):
+            with self.subTest(shape=clazz.__name__):
+                tb = init_toolbox(clazz, "entry-point-name",
+                                  config={"k": "v"})
+                self.assertIsInstance(tb, ToolBox)
+                self.assertTrue(tb.toolbox_id)
+
+    def test_config_reaches_the_plugin(self):
+        from ovos_plugin_manager.persona import init_toolbox
+        for clazz in (_HidesId, _TakesIdAndBus, _TakesKwargs):
+            with self.subTest(shape=clazz.__name__):
+                tb = init_toolbox(clazz, "entry-point-name",
+                                  config={"k": "v"})
+                self.assertEqual(tb.config, {"k": "v"})
+
+    def test_plugin_id_wins_over_entry_point_name(self):
+        # a plugin that declares its own id keeps it; the entry-point name is
+        # only a fallback for plugins that declare none
+        from ovos_plugin_manager.persona import init_toolbox
+        tb = init_toolbox(_HidesId, "some-other-name")
+        self.assertEqual(tb.toolbox_id, "hides-id")
+
+        tb = init_toolbox(_TakesIdAndBus, "some-other-name")
+        self.assertEqual(tb.toolbox_id, "some-other-name")
+
+    def test_bus_is_bound_whatever_the_signature(self):
+        from ovos_utils.fakebus import FakeBus
+        from ovos_plugin_manager.persona import init_toolbox
+        for clazz in (_HidesId, _TakesIdAndBus, _TakesKwargs):
+            with self.subTest(shape=clazz.__name__):
+                bus = FakeBus()
+                tb = init_toolbox(clazz, "entry-point-name", bus=bus)
+                self.assertIs(tb.bus, bus)
+
+    def test_no_bus_leaves_it_unbound(self):
+        from ovos_plugin_manager.persona import init_toolbox
+        tb = init_toolbox(_HidesId, "entry-point-name")
+        self.assertIsNone(tb.bus)
+
+    @patch("ovos_plugin_manager.persona.find_toolbox_plugins")
+    def test_load_toolbox_plugin_missing_returns_none(self, find_toolboxes):
+        from ovos_plugin_manager.persona import load_toolbox_plugin
+        find_toolboxes.return_value = {}
+        self.assertIsNone(load_toolbox_plugin("not-installed"))
+
+    @patch("ovos_plugin_manager.persona.find_toolbox_plugins")
+    def test_load_toolbox_plugins_skips_failures(self, find_toolboxes):
+        from ovos_plugin_manager.persona import load_toolbox_plugins
+
+        class _Explodes(ToolBox):
+            def __init__(self, config=None):
+                raise RuntimeError("boom")
+
+            def discover_tools(self) -> List:
+                return []
+
+        find_toolboxes.return_value = {"good": _HidesId, "bad": _Explodes}
+        loaded = load_toolbox_plugins()
+        self.assertEqual(len(loaded), 1)
+        self.assertEqual(loaded[0].toolbox_id, "hides-id")


### PR DESCRIPTION
## The bug

**No shipped `ToolBox` plugin can be loaded by any loader in the ecosystem
today.**

The base class takes `(toolbox_id, config=None, bus=None)`. Every plugin hides
the id and exposes only `(config=None)`, passing its own id up. So loaders have
to guess, and each guesses differently:

| Loader | Call |
|---|---|
| `ovos-persona-server` | `cls(toolbox_id=name)` |
| `ovos-PHAL-plugin-tools` | `cls(config=..., bus=self.bus)` |
| `ovos-agentic-loop` | `cls(config=..., bus=bus)` |

Every one of those raises `TypeError` against every shipped plugin:

```
ovos-wolfram-alpha-tools: WolframAlphaToolbox (self, config=None)
   persona-server         TypeError: unexpected keyword argument 'toolbox_id'
   agentic-loop/PHAL      TypeError: unexpected keyword argument 'bus'
ovos-wordnet-tool:        WordnetToolbox (self, config=None)
   persona-server         TypeError: unexpected keyword argument 'toolbox_id'
   agentic-loop/PHAL      TypeError: unexpected keyword argument 'bus'
```

8 of the 8 toolboxes installed on my machine rejected both call shapes.

Each loader catches the exception and logs a warning, so nothing fails loudly.
The toolboxes are simply never there: the Persona Server's `/tools/manual` and
`/mcp` surfaces come back empty, the PHAL `ovos.tools.*` bus API exposes
nothing, and every agentic loop silently degrades to a plain LLM with no tools.

## The fix

`init_toolbox(clazz, toolbox_id, config=None, bus=None)` inspects the subclass
and passes only the keywords it declares — or all of them, if it takes
`**kwargs` — then fills in `toolbox_id` and binds the bus afterwards.

A plugin that declares its own id keeps it; the entry-point name is only a
fallback for plugins that declare none.

Also adds `load_toolbox_plugin()` / `load_toolbox_plugins()`, so loaders have
one call to make instead of reimplementing discovery plus construction. The
three loader repos can then drop their own versions — I am happy to open those
follow-ups once the shape here is agreed.

**This asks nothing of existing plugins.** All three signatures in use keep
working, so nothing has to be republished.

Verified against the real plugins after the change:

```
  OK   ovos-wolfram-alpha-tools   id='ovos-wolfram-alpha-tools' tools=1 bus=yes
  OK   ovos-wordnet-tool          id='ovos-wordnet-tools'       tools=2 bus=yes
```

## Alternative considered

Forcing one signature on plugins and republishing all of them. That breaks
every installed toolbox until each is updated, and it does not help the
loaders, which would still each construct plugins their own way. Making the
construction tolerant in one place seemed the smaller change.

## Tests

Eight added to `test/unittests/test_persona.py`, over synthetic subclasses in
the three signature shapes seen in the wild, so they do not depend on which
plugins happen to be installed: construction, config pass-through, plugin id
winning over the entry-point name, bus binding, no-bus, a missing plugin
returning `None`, and one bad plugin not taking the others down.

Full unit suite: 1139 passed.

## How this surfaced

Found while auditing the ovos-technical-manual agent pages against source: the
manual documented a construction contract, and no loader or plugin matched it.