### PR TITLE
Use stdlib importlib.metadata instead of importlib_metadata + pkg_resources fallback

### DIFF
--- a/ovos_plugin_manager/utils/__init__.py
+++ b/ovos_plugin_manager/utils/__init__.py
@@ -211,38 +211,30 @@ def find_plugins(plug_type: PluginTypes = None) -> dict:
 
 find_plugins._errored = []
 
-# compat with older python versions
-try:
-    from importlib_metadata import entry_points
+# stdlib importlib.metadata (Python 3.8+) covers this project's own
+# `requires-python = ">=3.10"` -- the external importlib_metadata
+# backport package and the pkg_resources fallback are both unnecessary
+# now. Confirmed for real: a fresh venv without importlib_metadata
+# installed fell through to pkg_resources, which itself raised
+# ModuleNotFoundError -- setuptools no longer bundles pkg_resources by
+# default in recent releases (it's slated for removal entirely). Using
+# the stdlib module directly removes both failure modes at once, with
+# no new dependency to declare.
+from importlib.metadata import entry_points
 
-    def _iter_plugins(plug_type):
-        """
-        Yields all entry points for the specified plugin group.
-        
-        Parameters:
-            plug_type: The entry point group name to search for.
-        
-        Yields:
-            Entry points belonging to the specified group.
-        """
-        for entry_point in entry_points(group=plug_type):
-            yield entry_point
-except ImportError:
 
-    import pkg_resources  # deprecated in newer python versions
+def _iter_plugins(plug_type):
+    """
+    Yields all entry points for the specified plugin group.
 
-    def _iter_plugins(plug_type):
-        """
-        Yield all entry points for the specified plugin group using pkg_resources.
-        
-        Parameters:
-            plug_type (str): The entry point group name to search for.
-        
-        Yields:
-            EntryPoint: Each discovered entry point in the specified group.
-        """
-        for entry_point in pkg_resources.iter_entry_points(plug_type):
-            yield entry_point
+    Parameters:
+        plug_type: The entry point group name to search for.
+
+    Yields:
+        Entry points belonging to the specified group.
+    """
+    for entry_point in entry_points(group=plug_type):
+        yield entry_point
 
 
 def _iter_entrypoints(plug_type: Union[str, PluginTypes]):


### PR DESCRIPTION
## What
Replaces the `try: from importlib_metadata import entry_points / except ImportError: import pkg_resources` fallback in `_iter_plugins()` with a direct `from importlib.metadata import entry_points` (stdlib).

## Why
This project already requires `python_requires >= 3.10` (`pyproject.toml`), well past the Python 3.8 floor for stdlib `importlib.metadata`. Both the external `importlib_metadata` backport and the `pkg_resources` fallback are unnecessary now.

Confirmed as a real, reproducible bug on real hardware, not just a style cleanup: in a fresh virtualenv where `importlib_metadata` isn't installed (it's not declared as a dependency of this package), `_iter_plugins()` falls through to the `pkg_resources` branch -- which itself raises `ModuleNotFoundError`, since recent `setuptools` releases no longer bundle `pkg_resources` by default (and are removing it entirely per the upstream deprecation notice). This broke skill loading end-to-end for us -- reproduced consistently via `skill-ovos-stop`: `ModuleNotFoundError: No module named 'pkg_resources'`.

Using `importlib.metadata` directly removes both failure modes at once, with no new dependency to declare.

## Testing
All 27 existing tests in `test/unittests/test_utils.py` pass unchanged against this change.

## Context
Found while building a venv-per-skill isolation layer for a Home Assistant integration project -- happy to share more reproduction detail if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated plugin discovery to use Python’s standard library.
  * Removed legacy compatibility paths for plugin discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->