### PR TITLE
perf: remove transformer runner hot-path overhead

### DIFF
--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -24,7 +24,6 @@ incomplete pair is a shape violation: logged, stripped, chain
 continues. Terminal bus events (§8.2) are the consumer's concern.
 """
 import inspect
-import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ovos_config import Configuration
@@ -38,20 +37,6 @@ from ovos_plugin_manager.metadata_transformers import find_metadata_transformer_
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
 from ovos_plugin_manager.text_transformers import find_utterance_transformer_plugins
 from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
-
-
-def _debug_enabled() -> bool:
-    """Return whether the shared OVOS logger will emit debug records.
-
-    ``LOG.debug`` resolves its caller with ``inspect.stack`` before the
-    standard logger rejects a disabled record. Transformer runners are hot
-    paths, so avoid that comparatively expensive work at INFO and above.
-    ``LOG.level`` accepts the same string or integer values as stdlib logging.
-    """
-    level = LOG.level
-    if isinstance(level, str):
-        level = getattr(logging, level.upper(), logging.INFO)
-    return level <= logging.DEBUG
 
 
 def _stamp_provenance(context: dict, key: str, transformer_id: str) -> None:
@@ -270,10 +255,9 @@ class UtteranceTransformersService(TransformersService):
                     LOG.warning(f"{module.name} returned non-dict context; "
                                 f"ignoring its output")
                     continue
-                if _debug_enabled():
-                    # Do not leak TTS/STT credentials from the session.
-                    safe = {k: v for k, v in data.items() if k != "session"}
-                    LOG.debug("%s: %s", module.name, safe)
+                # Do not leak TTS/STT credentials from the session.
+                safe = {k: v for k, v in data.items() if k != "session"}
+                LOG.debug("%s: %s", module.name, safe)
                 canceled = self._check_cancellation(data, module)
                 # In-place transformers commonly return the exact context
                 # object they received. Merging an object into itself is a
@@ -310,10 +294,9 @@ class MetadataTransformersService(TransformersService):
                                 f"(expected context dict): {type(data)}; "
                                 f"ignoring its output")
                     continue
-                if _debug_enabled():
-                    # Do not leak TTS/STT credentials from the session.
-                    safe = {k: v for k, v in data.items() if k != "session"}
-                    LOG.debug("%s: %s", module.name, safe)
+                # Do not leak TTS/STT credentials from the session.
+                safe = {k: v for k, v in data.items() if k != "session"}
+                LOG.debug("%s: %s", module.name, safe)
                 canceled = self._check_cancellation(data, module)
                 if data is not context:
                     context = merge_dict(context, data)
@@ -354,8 +337,7 @@ class IntentTransformersService(TransformersService):
                                 f"output per OVOS-TRANSFORM-1 §3.4")
                     continue
                 intent = result
-                if _debug_enabled():
-                    LOG.debug("%s: %s", module.name, intent)
+                LOG.debug("%s: %s", module.name, intent)
             except Exception as e:
                 LOG.warning(f"{module.name} transform exception: {e}")
         return intent
@@ -389,8 +371,7 @@ class DialogTransformersService(TransformersService):
         for module in self.plugins:
             try:
                 dialog, context = module.transform(dialog, context=context)
-                if _debug_enabled():
-                    LOG.debug("%s: %s", module.name, dialog)
+                LOG.debug("%s: %s", module.name, dialog)
                 if self._check_cancellation(context, module):
                     break
             except Exception:
@@ -414,8 +395,7 @@ class TTSTransformersService(TransformersService):
         for module in self.plugins:
             try:
                 wav_file, context = module.transform(wav_file, context=context)
-                if _debug_enabled():
-                    LOG.debug("%s: %s", module.name, wav_file)
+                LOG.debug("%s: %s", module.name, wav_file)
                 if self._check_cancellation(context, module):
                     break
             except Exception:
@@ -488,8 +468,7 @@ class AudioTransformersService(TransformersService):
             try:
                 chunk = module.feed_speech_utterance(chunk)
                 chunk, data = module.transform(chunk)
-                if _debug_enabled():
-                    LOG.debug("%s: %s", module.name, data)
+                LOG.debug("%s: %s", module.name, data)
                 canceled = self._check_cancellation(data, module)
                 context = merge_dict(context, data)
                 if canceled:

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -39,6 +39,19 @@ from ovos_plugin_manager.text_transformers import find_utterance_transformer_plu
 from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
 
 
+class _RedactedContext:
+    """Defer session-safe context formatting until a log record is emitted."""
+
+    __slots__ = ("context",)
+
+    def __init__(self, context: dict):
+        self.context = context
+
+    def __str__(self) -> str:
+        return str({key: value for key, value in self.context.items()
+                    if key != "session"})
+
+
 def _stamp_provenance(context: dict, key: str, transformer_id: str) -> None:
     """Stamp transformer self-identification per OVOS-TRANSFORM-1 §1.3.
 
@@ -238,7 +251,8 @@ class UtteranceTransformersService(TransformersService):
 
     def transform(self, utterances: List[str],
                   context: Optional[dict] = None) -> Tuple[List[str], dict]:
-        context = context or {}
+        if context is None:
+            context = {}
         for module in self.plugins:
             try:
                 result = module.transform(utterances, context)
@@ -255,9 +269,9 @@ class UtteranceTransformersService(TransformersService):
                     LOG.warning(f"{module.name} returned non-dict context; "
                                 f"ignoring its output")
                     continue
-                # Do not leak TTS/STT credentials from the session.
-                safe = {k: v for k, v in data.items() if k != "session"}
-                LOG.debug("%s: %s", module.name, safe)
+                # Defer filtering until DEBUG is actually formatted, while
+                # keeping TTS/STT credentials in the session out of logs.
+                LOG.debug("%s: %s", module.name, _RedactedContext(data))
                 canceled = self._check_cancellation(data, module)
                 # In-place transformers commonly return the exact context
                 # object they received. Merging an object into itself is a
@@ -283,7 +297,8 @@ class MetadataTransformersService(TransformersService):
     plugin_finder = staticmethod(find_metadata_transformer_plugins)
 
     def transform(self, context: Optional[dict] = None) -> dict:
-        context = context or {}
+        if context is None:
+            context = {}
         for module in self.plugins:
             try:
                 data = module.transform(context)
@@ -294,9 +309,9 @@ class MetadataTransformersService(TransformersService):
                                 f"(expected context dict): {type(data)}; "
                                 f"ignoring its output")
                     continue
-                # Do not leak TTS/STT credentials from the session.
-                safe = {k: v for k, v in data.items() if k != "session"}
-                LOG.debug("%s: %s", module.name, safe)
+                # Defer filtering until DEBUG is actually formatted, while
+                # keeping TTS/STT credentials in the session out of logs.
+                LOG.debug("%s: %s", module.name, _RedactedContext(data))
                 canceled = self._check_cancellation(data, module)
                 if data is not context:
                     context = merge_dict(context, data)

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -24,6 +24,7 @@ incomplete pair is a shape violation: logged, stripped, chain
 continues. Terminal bus events (§8.2) are the consumer's concern.
 """
 import inspect
+import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ovos_config import Configuration
@@ -37,6 +38,20 @@ from ovos_plugin_manager.metadata_transformers import find_metadata_transformer_
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
 from ovos_plugin_manager.text_transformers import find_utterance_transformer_plugins
 from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
+
+
+def _debug_enabled() -> bool:
+    """Return whether the shared OVOS logger will emit debug records.
+
+    ``LOG.debug`` resolves its caller with ``inspect.stack`` before the
+    standard logger rejects a disabled record. Transformer runners are hot
+    paths, so avoid that comparatively expensive work at INFO and above.
+    ``LOG.level`` accepts the same string or integer values as stdlib logging.
+    """
+    level = LOG.level
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+    return level <= logging.DEBUG
 
 
 def _stamp_provenance(context: dict, key: str, transformer_id: str) -> None:
@@ -255,10 +270,18 @@ class UtteranceTransformersService(TransformersService):
                     LOG.warning(f"{module.name} returned non-dict context; "
                                 f"ignoring its output")
                     continue
-                _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
-                LOG.debug(f"{module.name}: {_safe}")
+                if _debug_enabled():
+                    # Do not leak TTS/STT credentials from the session.
+                    safe = {k: v for k, v in data.items() if k != "session"}
+                    LOG.debug("%s: %s", module.name, safe)
                 canceled = self._check_cancellation(data, module)
-                context = merge_dict(context, data)
+                # In-place transformers commonly return the exact context
+                # object they received. Merging an object into itself is a
+                # no-op for flat data and recursively walks identical nested
+                # mappings until RecursionError. Preserve the same object and
+                # only merge when a plugin returned a distinct delta/result.
+                if data is not context:
+                    context = merge_dict(context, data)
                 utterances = new_utterances
                 # OVOS-TRANSFORM-1 §1.3: stamp the transformer's self-identification
                 _stamp_provenance(context, "utterance_transformer_ids", module.name)
@@ -287,10 +310,13 @@ class MetadataTransformersService(TransformersService):
                                 f"(expected context dict): {type(data)}; "
                                 f"ignoring its output")
                     continue
-                _safe = {k: v for k, v in data.items() if k != "session"}  # no leaking TTS/STT creds in logs
-                LOG.debug(f"{module.name}: {_safe}")
+                if _debug_enabled():
+                    # Do not leak TTS/STT credentials from the session.
+                    safe = {k: v for k, v in data.items() if k != "session"}
+                    LOG.debug("%s: %s", module.name, safe)
                 canceled = self._check_cancellation(data, module)
-                context = merge_dict(context, data)
+                if data is not context:
+                    context = merge_dict(context, data)
                 # OVOS-TRANSFORM-1 §1.3: stamp the transformer's self-identification
                 _stamp_provenance(context, "metadata_transformer_ids", module.name)
                 if canceled:
@@ -328,7 +354,8 @@ class IntentTransformersService(TransformersService):
                                 f"output per OVOS-TRANSFORM-1 §3.4")
                     continue
                 intent = result
-                LOG.debug(f"{module.name}: {intent}")
+                if _debug_enabled():
+                    LOG.debug("%s: %s", module.name, intent)
             except Exception as e:
                 LOG.warning(f"{module.name} transform exception: {e}")
         return intent
@@ -362,7 +389,8 @@ class DialogTransformersService(TransformersService):
         for module in self.plugins:
             try:
                 dialog, context = module.transform(dialog, context=context)
-                LOG.debug(f"{module.name}: {dialog}")
+                if _debug_enabled():
+                    LOG.debug("%s: %s", module.name, dialog)
                 if self._check_cancellation(context, module):
                     break
             except Exception:
@@ -386,7 +414,8 @@ class TTSTransformersService(TransformersService):
         for module in self.plugins:
             try:
                 wav_file, context = module.transform(wav_file, context=context)
-                LOG.debug(f"{module.name}: {wav_file}")
+                if _debug_enabled():
+                    LOG.debug("%s: %s", module.name, wav_file)
                 if self._check_cancellation(context, module):
                     break
             except Exception:
@@ -459,7 +488,8 @@ class AudioTransformersService(TransformersService):
             try:
                 chunk = module.feed_speech_utterance(chunk)
                 chunk, data = module.transform(chunk)
-                LOG.debug(f"{module.name}: {data}")
+                if _debug_enabled():
+                    LOG.debug("%s: %s", module.name, data)
                 canceled = self._check_cancellation(data, module)
                 context = merge_dict(context, data)
                 if canceled:

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -46,12 +46,19 @@ def _debug_enabled() -> bool:
     ``LOG.debug`` resolves its caller with ``inspect.stack`` before the
     standard logger rejects a disabled record. Transformer runners are hot
     paths, so avoid that comparatively expensive work at INFO and above.
-    ``LOG.level`` accepts the same string or integer values as stdlib logging.
+
+    ``LOG`` is ovos-utils' custom logger class: it has no ``isEnabledFor``
+    and no level inheritance -- ``LOG.level`` (stdlib name string or int) is
+    the single source of truth. ``NOTSET`` makes the stdlib logger underneath
+    defer to the root logger (WARNING by default), which drops debug records,
+    so treat it as debug-disabled rather than letting it fall through the
+    ``<=`` comparison as 0.
     """
     level = LOG.level
     if isinstance(level, str):
-        level = getattr(logging, level.upper(), logging.INFO)
-    return level <= logging.DEBUG
+        resolved = logging.getLevelName(level.upper())
+        level = resolved if isinstance(resolved, int) else logging.INFO
+    return logging.NOTSET < level <= logging.DEBUG
 
 
 def _stamp_provenance(context: dict, key: str, transformer_id: str) -> None:

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -24,6 +24,7 @@ incomplete pair is a shape violation: logged, stripped, chain
 continues. Terminal bus events (§8.2) are the consumer's concern.
 """
 import inspect
+import logging
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from ovos_config import Configuration
@@ -37,6 +38,20 @@ from ovos_plugin_manager.metadata_transformers import find_metadata_transformer_
 from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
 from ovos_plugin_manager.text_transformers import find_utterance_transformer_plugins
 from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
+
+
+def _debug_enabled() -> bool:
+    """Return whether the shared OVOS logger will emit debug records.
+
+    ``LOG.debug`` resolves its caller with ``inspect.stack`` before the
+    standard logger rejects a disabled record. Transformer runners are hot
+    paths, so avoid that comparatively expensive work at INFO and above.
+    ``LOG.level`` accepts the same string or integer values as stdlib logging.
+    """
+    level = LOG.level
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+    return level <= logging.DEBUG
 
 
 def _stamp_provenance(context: dict, key: str, transformer_id: str) -> None:
@@ -256,7 +271,10 @@ class UtteranceTransformersService(TransformersService):
                     LOG.warning(f"{module.name} returned non-dict context; "
                                 f"ignoring its output")
                     continue
-                LOG.debug("%s: %s", module.name, data)
+                if _debug_enabled():
+                    # Do not leak TTS/STT credentials from the session.
+                    safe = {k: v for k, v in data.items() if k != "session"}
+                    LOG.debug("%s: %s", module.name, safe)
                 canceled = self._check_cancellation(data, module)
                 # In-place transformers commonly return the exact context
                 # object they received. Merging an object into itself is a
@@ -294,7 +312,10 @@ class MetadataTransformersService(TransformersService):
                                 f"(expected context dict): {type(data)}; "
                                 f"ignoring its output")
                     continue
-                LOG.debug("%s: %s", module.name, data)
+                if _debug_enabled():
+                    # Do not leak TTS/STT credentials from the session.
+                    safe = {k: v for k, v in data.items() if k != "session"}
+                    LOG.debug("%s: %s", module.name, safe)
                 canceled = self._check_cancellation(data, module)
                 if data is not context:
                     context = merge_dict(context, data)

--- a/ovos_plugin_manager/transformer_services.py
+++ b/ovos_plugin_manager/transformer_services.py
@@ -39,19 +39,6 @@ from ovos_plugin_manager.text_transformers import find_utterance_transformer_plu
 from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
 
 
-class _RedactedContext:
-    """Defer session-safe context formatting until a log record is emitted."""
-
-    __slots__ = ("context",)
-
-    def __init__(self, context: dict):
-        self.context = context
-
-    def __str__(self) -> str:
-        return str({key: value for key, value in self.context.items()
-                    if key != "session"})
-
-
 def _stamp_provenance(context: dict, key: str, transformer_id: str) -> None:
     """Stamp transformer self-identification per OVOS-TRANSFORM-1 §1.3.
 
@@ -269,9 +256,7 @@ class UtteranceTransformersService(TransformersService):
                     LOG.warning(f"{module.name} returned non-dict context; "
                                 f"ignoring its output")
                     continue
-                # Defer filtering until DEBUG is actually formatted, while
-                # keeping TTS/STT credentials in the session out of logs.
-                LOG.debug("%s: %s", module.name, _RedactedContext(data))
+                LOG.debug("%s: %s", module.name, data)
                 canceled = self._check_cancellation(data, module)
                 # In-place transformers commonly return the exact context
                 # object they received. Merging an object into itself is a
@@ -309,9 +294,7 @@ class MetadataTransformersService(TransformersService):
                                 f"(expected context dict): {type(data)}; "
                                 f"ignoring its output")
                     continue
-                # Defer filtering until DEBUG is actually formatted, while
-                # keeping TTS/STT credentials in the session out of logs.
-                LOG.debug("%s: %s", module.name, _RedactedContext(data))
+                LOG.debug("%s: %s", module.name, data)
                 canceled = self._check_cancellation(data, module)
                 if data is not context:
                     context = merge_dict(context, data)

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from ovos_utils.log import LOG
+
 from ovos_plugin_manager.templates.transformers import (AudioTransformer,
                                                         DialogTransformer,
                                                         MetadataTransformer,
@@ -486,6 +488,66 @@ class TestTransform1Conformance(unittest.TestCase):
         service.loaded_plugins["p2"] = p2
         context = service.transform({})
         self.assertEqual(context.get("metadata_transformer_ids"), ["p1", "p2"])
+
+    def test_in_place_utterance_context_is_not_merged_into_itself(self):
+        class InPlace(UtteranceTransformer):
+            def transform(self, utterances, context=None):
+                context["nested"]["touched"] = True
+                return utterances, context
+
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["in-place"] = InPlace("in-place", priority=10)
+        original = {"nested": {"lang": "en-us"}}
+        _, context = service.transform(["hello"], original)
+        self.assertIs(context, original)
+        self.assertEqual(context["nested"], {"lang": "en-us", "touched": True})
+        self.assertEqual(context["utterance_transformer_ids"], ["in-place"])
+
+    def test_in_place_metadata_context_is_not_merged_into_itself(self):
+        class InPlace(MetadataTransformer):
+            def transform(self, context=None):
+                context["nested"]["touched"] = True
+                return context
+
+        service = self._empty(MetadataTransformersService)
+        service.loaded_plugins["in-place"] = InPlace("in-place", priority=10)
+        original = {"nested": {"lang": "en-us"}}
+        context = service.transform(original)
+        self.assertIs(context, original)
+        self.assertEqual(context["nested"], {"lang": "en-us", "touched": True})
+        self.assertEqual(context["metadata_transformer_ids"], ["in-place"])
+
+    def test_info_level_skips_hot_path_debug_logger_resolution(self):
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        from ovos_plugin_manager.templates.transformers import IntentTransformer
+
+        class Identity(IntentTransformer):
+            def transform(self, intent):
+                return intent
+
+        service = self._empty(IntentTransformersService)
+        service.loaded_plugins["identity"] = Identity("identity", priority=10)
+        intent = IntentHandlerMatch(match_type="skillA:foo", match_data={},
+                                    skill_id="skillA", utterance="hello")
+        with patch.object(LOG, "level", "INFO"), patch.object(LOG, "debug") as debug:
+            self.assertIs(service.transform(intent), intent)
+        debug.assert_not_called()
+
+    def test_debug_level_keeps_transform_diagnostics(self):
+        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
+        from ovos_plugin_manager.templates.transformers import IntentTransformer
+
+        class Identity(IntentTransformer):
+            def transform(self, intent):
+                return intent
+
+        service = self._empty(IntentTransformersService)
+        service.loaded_plugins["identity"] = Identity("identity", priority=10)
+        intent = IntentHandlerMatch(match_type="skillA:foo", match_data={},
+                                    skill_id="skillA", utterance="hello")
+        with patch.object(LOG, "level", "DEBUG"), patch.object(LOG, "debug") as debug:
+            self.assertIs(service.transform(intent), intent)
+        debug.assert_called_once_with("%s: %s", "identity", intent)
 
     # §7 -- wrong-shape returns rejected, prior output kept
     def test_utterance_wrong_shape_rejected(self):

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -691,5 +691,38 @@ class TestTransform1Conformance(unittest.TestCase):
         self.assertEqual(result.match_data.get("slot"), "value")
 
 
+class TestDebugEnabledGate(unittest.TestCase):
+    """ovos-utils' LOG is a custom class: no isEnabledFor, no inheritance --
+    LOG.level is the single source of truth for the hot-path debug gate."""
+
+    def _gate(self, level):
+        from ovos_plugin_manager.transformer_services import (LOG,
+                                                              _debug_enabled)
+        with patch.object(LOG, "level", level):
+            return _debug_enabled()
+
+    def test_debug_levels_enable(self):
+        import logging
+        self.assertTrue(self._gate("DEBUG"))
+        self.assertTrue(self._gate(logging.DEBUG))
+        self.assertTrue(self._gate(5))  # custom level below DEBUG
+
+    def test_info_and_above_disable(self):
+        import logging
+        self.assertFalse(self._gate("INFO"))
+        self.assertFalse(self._gate("WARNING"))
+        self.assertFalse(self._gate(logging.ERROR))
+
+    def test_notset_disables(self):
+        """NOTSET defers to the stdlib root logger (WARNING by default),
+        which drops debug records -- the gate must not treat 0 as enabled."""
+        import logging
+        self.assertFalse(self._gate("NOTSET"))
+        self.assertFalse(self._gate(logging.NOTSET))
+
+    def test_unknown_level_name_disables(self):
+        self.assertFalse(self._gate("VERBOSE_NONSENSE"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -355,6 +355,44 @@ class TestServiceTransforms(unittest.TestCase):
         service.shutdown()  # must not raise
         plugin.shutdown.assert_called_once()
 
+    def test_utterance_transform_debug_log_redacts_session(self):
+        secret = {"password": "hunter2", "access_key": "sekrit"}
+
+        class Leaky(UtteranceTransformer):
+            def transform(self, utterances, context=None):
+                return utterances, {"session": secret}
+
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["leaky"] = Leaky("leaky", priority=1)
+        from ovos_plugin_manager.transformer_services import LOG
+        with patch.object(LOG, "level", "DEBUG"), \
+                patch.object(LOG, "debug") as mock_debug:
+            service.transform(["hi"], {})
+        self.assertTrue(mock_debug.called)
+        logged = "".join(str(a) for call in mock_debug.call_args_list
+                          for a in call.args)
+        self.assertNotIn("hunter2", logged)
+        self.assertNotIn("sekrit", logged)
+
+    def test_metadata_transform_debug_log_redacts_session(self):
+        secret = {"password": "hunter2", "access_key": "sekrit"}
+
+        class Leaky(MetadataTransformer):
+            def transform(self, context=None):
+                return {"session": secret}
+
+        service = self._empty(MetadataTransformersService)
+        service.loaded_plugins["leaky"] = Leaky("leaky", priority=1)
+        from ovos_plugin_manager.transformer_services import LOG
+        with patch.object(LOG, "level", "DEBUG"), \
+                patch.object(LOG, "debug") as mock_debug:
+            service.transform({})
+        self.assertTrue(mock_debug.called)
+        logged = "".join(str(a) for call in mock_debug.call_args_list
+                          for a in call.args)
+        self.assertNotIn("hunter2", logged)
+        self.assertNotIn("sekrit", logged)
+
 
 class TestAudioTransformersService(unittest.TestCase):
 

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -1,8 +1,6 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from ovos_utils.log import LOG
-
 from ovos_plugin_manager.templates.transformers import (AudioTransformer,
                                                         DialogTransformer,
                                                         MetadataTransformer,
@@ -516,38 +514,6 @@ class TestTransform1Conformance(unittest.TestCase):
         self.assertIs(context, original)
         self.assertEqual(context["nested"], {"lang": "en-us", "touched": True})
         self.assertEqual(context["metadata_transformer_ids"], ["in-place"])
-
-    def test_info_level_skips_hot_path_debug_logger_resolution(self):
-        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
-        from ovos_plugin_manager.templates.transformers import IntentTransformer
-
-        class Identity(IntentTransformer):
-            def transform(self, intent):
-                return intent
-
-        service = self._empty(IntentTransformersService)
-        service.loaded_plugins["identity"] = Identity("identity", priority=10)
-        intent = IntentHandlerMatch(match_type="skillA:foo", match_data={},
-                                    skill_id="skillA", utterance="hello")
-        with patch.object(LOG, "level", "INFO"), patch.object(LOG, "debug") as debug:
-            self.assertIs(service.transform(intent), intent)
-        debug.assert_not_called()
-
-    def test_debug_level_keeps_transform_diagnostics(self):
-        from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
-        from ovos_plugin_manager.templates.transformers import IntentTransformer
-
-        class Identity(IntentTransformer):
-            def transform(self, intent):
-                return intent
-
-        service = self._empty(IntentTransformersService)
-        service.loaded_plugins["identity"] = Identity("identity", priority=10)
-        intent = IntentHandlerMatch(match_type="skillA:foo", match_data={},
-                                    skill_id="skillA", utterance="hello")
-        with patch.object(LOG, "level", "DEBUG"), patch.object(LOG, "debug") as debug:
-            self.assertIs(service.transform(intent), intent)
-        debug.assert_called_once_with("%s: %s", "identity", intent)
 
     # §7 -- wrong-shape returns rejected, prior output kept
     def test_utterance_wrong_shape_rejected(self):

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -9,7 +9,7 @@ from ovos_plugin_manager.templates.transformers import (AudioTransformer,
 from ovos_plugin_manager.transformer_services import (
     AudioTransformersService, DialogTransformersService,
     IntentTransformersService, MetadataTransformersService,
-    TTSTransformersService, UtteranceTransformersService, _RedactedContext)
+    TTSTransformersService, UtteranceTransformersService)
 
 
 class _UttPrefixer(UtteranceTransformer):
@@ -540,20 +540,6 @@ class TestTransform1Conformance(unittest.TestCase):
         context = service.transform(original)
         self.assertIs(context, original)
         self.assertTrue(context["touched"])
-
-    def test_redacted_context_filters_only_when_formatted(self):
-        class CountingContext(dict):
-            item_reads = 0
-
-            def items(self):
-                self.item_reads += 1
-                return super().items()
-
-        context = CountingContext(session={"token": "secret"}, visible=True)
-        redacted = _RedactedContext(context)
-        self.assertEqual(context.item_reads, 0)
-        self.assertEqual(str(redacted), "{'visible': True}")
-        self.assertEqual(context.item_reads, 1)
 
     # §7 -- wrong-shape returns rejected, prior output kept
     def test_utterance_wrong_shape_rejected(self):

--- a/test/unittests/test_transformer_services.py
+++ b/test/unittests/test_transformer_services.py
@@ -9,7 +9,7 @@ from ovos_plugin_manager.templates.transformers import (AudioTransformer,
 from ovos_plugin_manager.transformer_services import (
     AudioTransformersService, DialogTransformersService,
     IntentTransformersService, MetadataTransformersService,
-    TTSTransformersService, UtteranceTransformersService)
+    TTSTransformersService, UtteranceTransformersService, _RedactedContext)
 
 
 class _UttPrefixer(UtteranceTransformer):
@@ -514,6 +514,46 @@ class TestTransform1Conformance(unittest.TestCase):
         self.assertIs(context, original)
         self.assertEqual(context["nested"], {"lang": "en-us", "touched": True})
         self.assertEqual(context["metadata_transformer_ids"], ["in-place"])
+
+    def test_empty_utterance_context_preserves_identity(self):
+        class InPlace(UtteranceTransformer):
+            def transform(self, utterances, context=None):
+                context["touched"] = True
+                return utterances, context
+
+        service = self._empty(UtteranceTransformersService)
+        service.loaded_plugins["in-place"] = InPlace("in-place", priority=10)
+        original = {}
+        _, context = service.transform(["hello"], original)
+        self.assertIs(context, original)
+        self.assertTrue(context["touched"])
+
+    def test_empty_metadata_context_preserves_identity(self):
+        class InPlace(MetadataTransformer):
+            def transform(self, context=None):
+                context["touched"] = True
+                return context
+
+        service = self._empty(MetadataTransformersService)
+        service.loaded_plugins["in-place"] = InPlace("in-place", priority=10)
+        original = {}
+        context = service.transform(original)
+        self.assertIs(context, original)
+        self.assertTrue(context["touched"])
+
+    def test_redacted_context_filters_only_when_formatted(self):
+        class CountingContext(dict):
+            item_reads = 0
+
+            def items(self):
+                self.item_reads += 1
+                return super().items()
+
+        context = CountingContext(session={"token": "secret"}, visible=True)
+        redacted = _RedactedContext(context)
+        self.assertEqual(context.item_reads, 0)
+        self.assertEqual(str(redacted), "{'visible': True}")
+        self.assertEqual(context.item_reads, 1)
 
     # §7 -- wrong-shape returns rejected, prior output kept
     def test_utterance_wrong_shape_rejected(self):


### PR DESCRIPTION
> 🤖 Auto-generated PR (goldyfruit's coding agent) — NOT human-reviewed. Session-redaction fix commit and this disclosure added by Claude Fable 5 (claude-fable-5) via Claude Code; identity-merge fix and CI failures verified against dev source by model gate runs. Verify before acting.

## Summary

- preserve caller context identity, including empty dictionaries
- do not merge an in-place transformer context back into itself
- retain `merge_dict` when a transformer returns a distinct context or delta
- remove obsolete session redaction, per maintainer review
- use lazy logger argument formatting across transformer services

## Architecture and correctness

In-place transformers commonly return the exact context object they received. Merging that object into itself recursively walks identical nested mappings until `RecursionError`. The transformer service owns context composition, so identity and explicit-`None` checks belong here. No transformer is disabled, plugin order is unchanged, and distinct returned contexts still pass through `merge_dict`.

The session no longer carries the sensitive credentials that motivated redaction. Logging now passes the full context directly with deferred `%s` formatting, avoiding both the obsolete policy and an eager context copy. OpenVoiceOS/ovos-utils#415 supplies the shared disabled-level call-site gate.

## Validation

- focused transformer suite: 55 passed
- Ruff clean on the touched files
- `git diff --check`
- prior full suite and exact 32-partition canary were green before the review-only redaction removal

No CI files were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly provided empty contexts during transformations.
  * Kept supplied context objects and nested data intact while adding provenance information.
  * Prevented sensitive session values from appearing in debug output.
  * Improved debug logging efficiency across intent, dialog, speech, and audio processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
