### PR TITLE
fix: use the shared language-match helper for dialect configs

### DIFF
--- a/ovos_plugin_manager/utils/config.py
+++ b/ovos_plugin_manager/utils/config.py
@@ -1,6 +1,6 @@
 from typing import Optional, Union
 from ovos_config.config import Configuration
-from ovos_spec_tools import standardize_lang, lang_distance
+from ovos_spec_tools import standardize_lang, lang_matches
 from ovos_utils.log import LOG
 from ovos_plugin_manager.utils import load_plugin, find_plugins, PluginTypes, PluginConfigTypes
 
@@ -68,7 +68,7 @@ def get_valid_plugin_configs(configs: dict, lang: str,
         # Check other dialects of the requested language
         base_lang = standardize_lang(lang)
         for language, confs in configs.items():
-            if lang_distance(base_lang, language) < 10:
+            if lang_matches(base_lang, language):
                 for config in confs:
                     try:
                         if language != lang:
@@ -182,7 +182,7 @@ def get_plugin_language_configs(plug_type: PluginTypes, lang: str,
         if include_dialects:
             macro = standardize_lang(lang)
             for language, configs in plug_configs.items():
-                if lang_distance(macro, language) < 10:
+                if lang_matches(macro, language):
                     plugin_configs[plug] += configs
         elif lang in plug_configs:
             plugin_configs[plug] += plug_configs[lang]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "combo_lock~=0.3",
     "requests~=2.32",
     "quebra_frases",
-    "ovos-spec-tools[langcodes]>=0.0.1a2",
+    "ovos-spec-tools[langcodes]>=1.6.1a1",
     "importlib_metadata",
     "setuptools; python_version>='3.12'",
     "standard-aifc; python_version>='3.13'",

--- a/test/unittests/test_lang_distance_boundary.py
+++ b/test/unittests/test_lang_distance_boundary.py
@@ -1,0 +1,37 @@
+"""The language-distance boundary used to select dialect plugin configs."""
+import unittest
+
+from ovos_plugin_manager.utils.config import get_valid_plugin_configs
+
+MACROLANGUAGE_PAIRS = [("arz", "ar"), ("wuu", "zh")]
+REGIONAL_PAIRS = [("ar-SA", "ar"), ("en-AU", "en-GB"), ("pt-BR", "pt-PT")]
+UNRELATED_PAIRS = [("en", "zh"), ("es", "fr"), ("fr-CH", "de-CH"), ("af", "nl")]
+
+
+def _selected(requested: str, available: str) -> bool:
+    """True when the config filed under `available` is offered for `requested`."""
+    configs = {available: [{"module": "test", "priority": 50}]}
+    return bool(get_valid_plugin_configs(configs, requested,
+                                         include_dialects=True))
+
+
+class TestValidPluginConfigLangBoundary(unittest.TestCase):
+
+    def test_macrolanguage_config_is_offered(self):
+        for member, macro in MACROLANGUAGE_PAIRS:
+            with self.subTest(member=member):
+                self.assertTrue(_selected(member, macro))
+
+    def test_regional_config_is_offered(self):
+        for requested, available in REGIONAL_PAIRS:
+            with self.subTest(requested=requested):
+                self.assertTrue(_selected(requested, available))
+
+    def test_unrelated_config_is_not_offered(self):
+        for requested, available in UNRELATED_PAIRS:
+            with self.subTest(requested=requested):
+                self.assertFalse(_selected(requested, available))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) via Claude Code — NOT human-reviewed. Verify before acting.

Dialect configuration lookup in `ovos_plugin_manager/utils/config.py` compared language tags with a hand-written `distance < 10` check, which excluded pairs that sit exactly at the boundary the shared helper treats as a match (`arz` against `ar`, `wuu` against `zh`). The lookup now uses `ovos_spec_tools.lang_matches`, the same helper every other component uses, so a dialect config listed under a close macro-language is found the way the rest of the stack finds it.

The change only widens matching: a `<=` boundary can add matches but never drop one. A probe over `en`, `en-us`, `en-GB`, `pt`, `pt-br`, `pt-pt`, `zh-Hans`, `nb` and `no` selects the same config before and after; only the two boundary pairs above change, from excluded to included. `test/unittests/test_lang_distance_boundary.py` pins that boundary.

`pyproject.toml` raises the floor to `ovos-spec-tools>=1.6.1a1`, the first release that ships `lang_matches` with these semantics; that release is on PyPI. Full unit suite: 1019 passed, 49 skipped.

Verified by running code (model re-check, not human review): the probe table above on both the base and this branch, the installed `lang_matches` semantics from the pinned release, and the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language and dialect matching when selecting valid plugin configurations.
  - Macrolanguage and regional dialect configurations are now recognized more accurately.
  - Unrelated language configurations are correctly excluded.

- **Tests**
  - Added coverage for dialect matching boundaries, including supported and unsupported language combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->