### PR TITLE
fix: dispatch ChatEngine.continue_chat with keyword arguments

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -4,6 +4,21 @@ Behavior changes since the last stable release, newest first. This file is
 reset at each stable release; entries that remove or deprecate behavior
 become the deprecation ledger for the next semver cycle.
 
+## 2.11.1a5
+
+- `ChatEngine`'s built-in `stream_tokens`, `stream_sentences`, and
+  `MultimodalChatEngine.stream_chat` now call a subclass's `continue_chat`
+  override by keyword instead of positionally. A subclass that names or
+  orders its `continue_chat` parameters differently from the base signature
+  was previously fed silently wrong values by these wrappers; it now gets
+  the correctly named argument regardless of declaration order.
+- `ChatEngine.__init_subclass__` inspects a subclass's own `continue_chat`
+  override at class-definition time and logs one `LOG.warning`, naming the
+  class, if the override accepts neither a `tools` parameter nor `**kwargs`.
+  The warning never raises, so a non-conforming plugin still loads; it will
+  simply never receive tool definitions and silently ignore requests that
+  require tool calling.
+
 ## 2.11.1a3
 
 - `UtteranceTransformersService.transform` and `MetadataTransformersService.transform`

--- a/ovos_plugin_manager/templates/agents.py
+++ b/ovos_plugin_manager/templates/agents.py
@@ -1,5 +1,6 @@
 import abc
 import difflib
+import inspect
 import time
 from abc import ABC
 from dataclasses import dataclass, field
@@ -241,6 +242,29 @@ class ChatEngine(AbstractAgentEngine):
     # ``AgentMessage.tool_calls``. Tool-aware engines override this to True.
     supports_tools: bool = False
 
+    # Classes already warned about a non-conforming ``continue_chat`` signature.
+    _tools_warned_classes: set = set()
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        method = cls.__dict__.get("continue_chat")
+        if method is None:
+            return
+        try:
+            sig = inspect.signature(method)
+        except (TypeError, ValueError):
+            return
+        params = sig.parameters.values()
+        accepts_tools = "tools" in sig.parameters or \
+            any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params)
+        if not accepts_tools and cls not in ChatEngine._tools_warned_classes:
+            ChatEngine._tools_warned_classes.add(cls)
+            LOG.warning(f"{cls.__name__}.continue_chat does not accept a 'tools' "
+                        f"argument (or **kwargs). It will not receive tool "
+                        f"definitions when called with tools=..., and will silently "
+                        f"ignore requests that require tool calling. Add a 'tools' "
+                        f"parameter to conform to the ChatEngine contract.")
+
     @abc.abstractmethod
     def continue_chat(self, messages: List[AgentMessage],
                       session_id: str = "default",
@@ -290,7 +314,8 @@ class ChatEngine(AbstractAgentEngine):
         Returns:
             Iterable[str]: A stream of tokens/partial text.
         """
-        yield from self.continue_chat(messages, session_id, lang, units).content.split()
+        yield from self.continue_chat(messages=messages, session_id=session_id,
+                                      lang=lang, units=units).content.split()
 
     def stream_sentences(self, messages: List[AgentMessage],
                     session_id: str = "default",
@@ -316,7 +341,8 @@ class ChatEngine(AbstractAgentEngine):
         Returns:
             Iterable[str]: A stream of complete sentences.
         """
-        yield from self.continue_chat(messages, session_id, lang, units).content.split("\n")
+        yield from self.continue_chat(messages=messages, session_id=session_id,
+                                      lang=lang, units=units).content.split("\n")
 
     def get_response(self, utterance: str,
                      session_id: str = "default",
@@ -394,7 +420,8 @@ class MultimodalChatEngine(ChatEngine):
         Returns:
             Iterable[AgentMessage]: A stream of response messages.
         """
-        yield self.continue_chat(messages, session_id, lang, units)
+        yield self.continue_chat(messages=messages, session_id=session_id,
+                                 lang=lang, units=units)
 
     def get_response(self, utterance: str,
                      image_content: Optional[List[str]] = None,  # b64 encoded

--- a/test/unittests/test_agents.py
+++ b/test/unittests/test_agents.py
@@ -725,5 +725,88 @@ class TestOptionMatcherEngine(unittest.TestCase):
         self.assertIsNone(matcher.match_option("anything", []))
 
 
+# ---------------------------------------------------------------------------
+# Tests for ChatEngine __init_subclass__ 'tools' conformance check
+# ---------------------------------------------------------------------------
+
+class TestChatEngineToolsConformance(unittest.TestCase):
+    """Tests for the ChatEngine.__init_subclass__ 'tools' signature check."""
+
+    def test_conforming_subclass_no_warning(self) -> None:
+        """A subclass naming 'tools' produces no warning."""
+        with patch("ovos_plugin_manager.templates.agents.LOG") as mock_log:
+            class _ConformingEngine(ChatEngine):
+                def continue_chat(self, messages, session_id="default",
+                                  lang=None, units=None, tools=None):
+                    return AgentMessage(role=MessageRole.ASSISTANT, content="ok")
+
+            mock_log.warning.assert_not_called()
+
+    def test_non_conforming_subclass_warns_once(self) -> None:
+        """A subclass omitting 'tools' warns exactly once, naming the class."""
+        with patch("ovos_plugin_manager.templates.agents.LOG") as mock_log:
+            class _LegacyEngine(ChatEngine):
+                def continue_chat(self, messages, session_id="default",
+                                  lang=None, units=None):
+                    return AgentMessage(role=MessageRole.ASSISTANT, content="ok")
+
+            mock_log.warning.assert_called_once()
+            msg = mock_log.warning.call_args[0][0]
+            self.assertIn("_LegacyEngine", msg)
+
+            # instantiating the class again must not re-warn
+            _LegacyEngine()
+            _LegacyEngine()
+            mock_log.warning.assert_called_once()
+
+    def test_kwargs_subclass_no_warning(self) -> None:
+        """A subclass accepting **kwargs is considered conforming."""
+        with patch("ovos_plugin_manager.templates.agents.LOG") as mock_log:
+            class _KwargsEngine(ChatEngine):
+                def continue_chat(self, messages, session_id="default",
+                                  lang=None, units=None, **kwargs):
+                    return AgentMessage(role=MessageRole.ASSISTANT, content="ok")
+
+            mock_log.warning.assert_not_called()
+
+    def test_dispatch_uses_keyword_arguments(self) -> None:
+        """Base wrappers (stream_tokens/stream_sentences/get_response) call
+        continue_chat with keyword arguments, not positionally.
+
+        The subclass below declares ``lang`` and ``session_id`` in swapped
+        order relative to the base ``ChatEngine.continue_chat`` signature.
+        Under positional dispatch, the wrapper's ``self.continue_chat(messages,
+        session_id, lang, units)`` call would silently bind the caller's
+        ``session_id`` value into this subclass's ``lang`` parameter slot
+        (and vice versa) - a real regression that a same-order subclass can
+        never surface. Under keyword dispatch the values land in the
+        correctly named parameters regardless of declaration order.
+        """
+        calls = []
+
+        class _RecordingEngine(ChatEngine):
+            def continue_chat(self, messages, lang="default",
+                              session_id=None, units=None, *, tools=None):
+                calls.append(dict(messages=messages, session_id=session_id,
+                                  lang=lang, units=units, tools=tools))
+                return AgentMessage(role=MessageRole.ASSISTANT, content="hi there")
+
+        engine = _RecordingEngine()
+        msgs = [AgentMessage(role=MessageRole.USER, content="ping")]
+
+        list(engine.stream_tokens(msgs, session_id="s1", lang="en-us", units="metric"))
+        list(engine.stream_sentences(msgs, session_id="s2", lang="pt-pt", units="imperial"))
+        engine.get_response("hello", session_id="s3", lang="es-es", units="metric")
+
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(calls[0]["session_id"], "s1")
+        self.assertEqual(calls[0]["lang"], "en-us")
+        self.assertEqual(calls[0]["units"], "metric")
+        self.assertEqual(calls[1]["session_id"], "s2")
+        self.assertEqual(calls[1]["lang"], "pt-pt")
+        self.assertEqual(calls[2]["session_id"], "s3")
+        self.assertEqual(calls[2]["lang"], "es-es")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

The base `ChatEngine` wrappers (`stream_tokens`, `stream_sentences`, and `MultimodalChatEngine.stream_chat`) called a subclass's `continue_chat` override positionally. That means a subclass whose override names or orders its parameters differently from the base signature was silently fed the wrong values through these wrappers, with no error raised. This is a latent defect rather than a live outage: every `continue_chat` override in the current OVOS ecosystem happens to use the same four parameter names in the same order, so nothing breaks today, but nothing prevents a future override from drifting and being silently mis-fed. The only real caller that reaches `continue_chat` with `tools=` today is `ovos_agentic_loop/native_toolcall.py`, gated behind `supports_tools`, and the one plugin that sets `supports_tools = True` (`ovos-openai-plugin`) already declares a `tools` parameter, so this is a defense-in-depth fix, not a hotfix for an active crash.

The fix switches those three wrapper call sites to call `continue_chat` by keyword instead of positionally, so a signature mismatch surfaces the moment it exists rather than staying hidden. It also adds a `ChatEngine.__init_subclass__` hook that inspects a subclass's own `continue_chat` override at class-definition time and logs a single `LOG.warning`, naming the class, if the override accepts neither a `tools` parameter nor `**kwargs`. The warning never raises, so a non-conforming plugin still loads; it will just never receive tool definitions and silently ignore requests that require tool calling.

The regression test for the keyword-dispatch change previously could not tell keyword dispatch from positional dispatch, because its subclass declared `continue_chat`'s parameters in the same order the wrappers pass them — positional and keyword calls were observationally identical. It has been rewritten so the subclass declares `lang` before `session_id` (swapped from the base order) with `tools` keyword-only, and asserts on the captured values. Fail-before: reverting only the three wrapper call sites back to positional calls made the test fail with `AssertionError: 'en-us' != 's1'` (the caller's `session_id` value landed in the subclass's `lang` slot); restoring the keyword calls makes it pass again. The `__init_subclass__` conformance tests and their warn-once behavior are unchanged.

`docs/prerelease-quirks.md` gets a `2.11.1a5` entry describing both behavior changes for the next alpha.

Verified by running the full `test/unittests` suite in a fresh venv built from this branch: 1030 passed, 49 skipped, no regressions. The `test/unittests/test_agents.py` file alone: 72 passed, including the rewritten `test_dispatch_uses_keyword_arguments` and the three `TestChatEngineToolsConformance` tests. All of this was executed against real code paths (no mocked `continue_chat` dispatch) in a throwaway virtualenv built from an editable install of this worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat streaming compatibility by dispatching conversation continuation parameters by name, regardless of their declaration order.
  * Added support for tool-aware continuation handling across standard and multimodal chat flows.
  * Added a clear, one-time warning when custom chat engines do not support tool parameters.

* **Documentation**
  * Documented prerelease behavior and compatibility considerations for version 2.11.1a5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->