### PR TITLE
fix: guard media template seek/re-entry, add capability flags

### DIFF
--- a/ovos_plugin_manager/templates/audio.py
+++ b/ovos_plugin_manager/templates/audio.py
@@ -18,9 +18,20 @@ class AudioBackend(metaclass=ABCMeta):
         bus (MessageBusClient): OpenVoiceOS messagebus emitter
     """
 
+    #: Whether this backend can seek within a track. Backends that cannot
+    #: seek (e.g. live streams) should set this to False; consumers can
+    #: check it before calling seek_forward/seek_backward.
+    supports_seek = True
+
+    #: Whether this backend can pause/resume playback. Backends that cannot
+    #: pause (e.g. live streams) should set this to False; consumers can
+    #: check it before calling ocp_pause/ocp_resume.
+    supports_pause = True
+
     def __init__(self, config=None, bus=None, name=None):
         self.name = name or self.__class__.__name__
         self._now_playing = None  # single uri
+        self._ocp_playing = False  # tracks whether ocp_start has run without a matching stop/error
         self._tracks = []  # list of dicts for OCP entries
         self._idx = 0
         self._track_start_callback = None
@@ -203,8 +214,12 @@ class AudioBackend(metaclass=ABCMeta):
             seconds (int): number of seconds to seek, if negative rewind
         """
         miliseconds = seconds * 1000
-        new_pos = self.get_track_position() + miliseconds
-        self.set_track_position(new_pos)
+        position = self.get_track_position()
+        if position is None:
+            LOG.debug(f"{self.__class__.__name__} reported no track "
+                      f"position, ignoring seek_forward")
+            return
+        self.set_track_position(position + miliseconds)
 
     def seek_backward(self, seconds=1):
         """Rewind X seconds.
@@ -213,8 +228,12 @@ class AudioBackend(metaclass=ABCMeta):
             seconds (int): number of seconds to seek, if negative jump forward.
         """
         miliseconds = seconds * 1000
-        new_pos = self.get_track_position() - miliseconds
-        self.set_track_position(new_pos)
+        position = self.get_track_position()
+        if position is None:
+            LOG.debug(f"{self.__class__.__name__} reported no track "
+                      f"position, ignoring seek_backward")
+            return
+        self.set_track_position(position - miliseconds)
 
     def set_track_start_callback(self, callback_func):
         """Register callback on track start.
@@ -267,6 +286,7 @@ class AudioBackend(metaclass=ABCMeta):
         In ovos audio backends are single-track, playlists are handled by OCP
         """
         self._now_playing = uri
+        self._ocp_playing = False  # new track queued, ocp_start needs to (re)start playback
         LOG.debug(f"queuing for {self.__class__.__name__} playback: {uri}")
         self.bus.emit(Message("ovos.common_play.media.state",
                               {"state": MediaState.LOADING_MEDIA}))
@@ -280,7 +300,19 @@ class AudioBackend(metaclass=ABCMeta):
                                "length": self.get_track_length()}))
 
     def ocp_start(self):
-        """Emit OCP status events for play"""
+        """Emit OCP status events for play.
+
+        Idempotent: if playback was already started by a previous call and
+        has not since been stopped (ocp_stop) or errored (ocp_error), this
+        is a no-op. This prevents duplicate PLAYING/LOADED_MEDIA/track.state
+        events when ocp_start is invoked again while playback is already
+        active.
+        """
+        if self._ocp_playing:
+            LOG.debug(f"{self.__class__.__name__}.ocp_start called while "
+                      f"already playing, ignoring")
+            return
+        self._ocp_playing = True
         self.bus.emit(Message("ovos.common_play.player.state",
                               {"state": PlayerState.PLAYING}))
         self.bus.emit(Message("ovos.common_play.media.state",
@@ -291,14 +323,16 @@ class AudioBackend(metaclass=ABCMeta):
     def ocp_error(self):
         """Emit OCP status events for playback error"""
         if self._now_playing:
+            self._now_playing = None
+            self._ocp_playing = False
             self.bus.emit(Message("ovos.common_play.media.state",
                                   {"state": MediaState.INVALID_MEDIA}))
-            self._now_playing = None
 
     def ocp_stop(self):
         """Emit OCP status events for stop"""
         if self._now_playing:
             self._now_playing = None
+            self._ocp_playing = False
             self.bus.emit(Message("ovos.common_play.player.state",
                                   {"state": PlayerState.STOPPED}))
             self.bus.emit(Message("ovos.common_play.media.state",

--- a/ovos_plugin_manager/templates/media.py
+++ b/ovos_plugin_manager/templates/media.py
@@ -16,10 +16,21 @@ class MediaBackend(metaclass=ABCMeta):
        bus (MessageBusClient): Mycroft messagebus emitter
    """
 
+    #: Whether this backend can seek within a track. Backends that cannot
+    #: seek (e.g. live streams) should set this to False; consumers can
+    #: check it before calling seek_forward/seek_backward.
+    supports_seek = True
+
+    #: Whether this backend can pause/resume playback. Backends that cannot
+    #: pause (e.g. live streams) should set this to False; consumers can
+    #: check it before calling ocp_pause/ocp_resume.
+    supports_pause = True
+
     def __init__(self, config=None, bus=None):
         if MediaState is None:
             raise RuntimeError("Please update to ovos-utils~=0.1.")
         self._now_playing = None  # single uri
+        self._ocp_playing = False  # tracks whether ocp_start has run without a matching stop/error
         self._track_start_callback = None
         self.supports_mime_hints = False
         self.config = config or {}
@@ -35,13 +46,26 @@ class MediaBackend(metaclass=ABCMeta):
 
     def load_track(self, uri: str, metadata: dict = None):
         self._now_playing = uri
+        self._ocp_playing = False  # new track queued, ocp_start needs to (re)start playback
         self.meta.update(metadata or {})
         LOG.debug(f"queuing for {self.__class__.__name__} playback: {uri}")
         self.bus.emit(Message("ovos.common_play.media.state",
                               {"state": MediaState.LOADED_MEDIA}))
 
     def ocp_start(self):
-        """Emit OCP status events for play"""
+        """Emit OCP status events for play.
+
+        Idempotent: if playback was already started by a previous call and
+        has not since been stopped (ocp_stop) or errored (ocp_error), this
+        is a no-op. This prevents duplicate LOADED_MEDIA/PLAYING events and
+        a duplicate call to play() when ocp_start is invoked again while
+        playback is already active.
+        """
+        if self._ocp_playing:
+            LOG.debug(f"{self.__class__.__name__}.ocp_start called while "
+                      f"already playing, ignoring")
+            return
+        self._ocp_playing = True
         self.bus.emit(Message("ovos.common_play.player.state",
                               {"state": PlayerState.PLAYING}))
         self.bus.emit(Message("ovos.common_play.media.state",
@@ -52,6 +76,7 @@ class MediaBackend(metaclass=ABCMeta):
         """Emit OCP status events for playback error"""
         if self._now_playing:
             self._now_playing = None
+            self._ocp_playing = False
             self.bus.emit(Message("ovos.common_play.media.state",
                                   {"state": MediaState.INVALID_MEDIA}))
             self.bus.emit(Message("ovos.common_play.player.state",
@@ -61,6 +86,7 @@ class MediaBackend(metaclass=ABCMeta):
         """Emit OCP status events for stop"""
         if self._now_playing:
             self._now_playing = None
+            self._ocp_playing = False
             self.bus.emit(Message("ovos.common_play.player.state",
                                   {"state": PlayerState.STOPPED}))
             self.bus.emit(Message("ovos.common_play.media.state",
@@ -172,8 +198,12 @@ class MediaBackend(metaclass=ABCMeta):
             seconds (int): number of seconds to seek, if negative rewind
         """
         miliseconds = seconds * 1000
-        new_pos = self.get_track_position() + miliseconds
-        self.set_track_position(new_pos)
+        position = self.get_track_position()
+        if position is None:
+            LOG.debug(f"{self.__class__.__name__} reported no track "
+                      f"position, ignoring seek_forward")
+            return
+        self.set_track_position(position + miliseconds)
 
     def seek_backward(self, seconds=1):
         """Rewind X seconds.
@@ -182,8 +212,12 @@ class MediaBackend(metaclass=ABCMeta):
             seconds (int): number of seconds to seek, if negative jump forward.
         """
         miliseconds = seconds * 1000
-        new_pos = self.get_track_position() - miliseconds
-        self.set_track_position(new_pos)
+        position = self.get_track_position()
+        if position is None:
+            LOG.debug(f"{self.__class__.__name__} reported no track "
+                      f"position, ignoring seek_backward")
+            return
+        self.set_track_position(position - miliseconds)
 
     def track_info(self):
         """Get info about current playing track.
@@ -210,10 +244,12 @@ class AudioPlayerBackend(MediaBackend):
                               {"state": TrackState.QUEUED_AUDIO}))
 
     def ocp_start(self):
-        """Emit OCP status events for play"""
+        """Emit OCP status events for play. Idempotent, see MediaBackend.ocp_start."""
+        was_playing = self._ocp_playing
         super().ocp_start()
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.PLAYING_AUDIO}))
+        if not was_playing:
+            self.bus.emit(Message("ovos.common_play.track.state",
+                                  {"state": TrackState.PLAYING_AUDIO}))
 
 
 class RemoteAudioPlayerBackend(AudioPlayerBackend):
@@ -234,10 +270,12 @@ class VideoPlayerBackend(MediaBackend):
                               {"state": TrackState.QUEUED_VIDEO}))
 
     def ocp_start(self):
-        """Emit OCP status events for play"""
+        """Emit OCP status events for play. Idempotent, see MediaBackend.ocp_start."""
+        was_playing = self._ocp_playing
         super().ocp_start()
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.PLAYING_VIDEO}))
+        if not was_playing:
+            self.bus.emit(Message("ovos.common_play.track.state",
+                                  {"state": TrackState.PLAYING_VIDEO}))
 
 
 class RemoteVideoPlayerBackend(VideoPlayerBackend):
@@ -259,10 +297,12 @@ class WebPlayerBackend(MediaBackend):
                               {"state": TrackState.QUEUED_WEBVIEW}))
 
     def ocp_start(self):
-        """Emit OCP status events for play"""
+        """Emit OCP status events for play. Idempotent, see MediaBackend.ocp_start."""
+        was_playing = self._ocp_playing
         super().ocp_start()
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.PLAYING_WEBVIEW}))
+        if not was_playing:
+            self.bus.emit(Message("ovos.common_play.track.state",
+                                  {"state": TrackState.PLAYING_WEBVIEW}))
 
 
 class RemoteWebPlayerBackend(WebPlayerBackend):

--- a/test/unittests/test_audio_backend_template.py
+++ b/test/unittests/test_audio_backend_template.py
@@ -147,6 +147,66 @@ class TestAudioBackend(unittest.TestCase):
         self.backend.seek_backward(3)
         self.backend.set_track_position.assert_called_once_with(-3000)
 
+    def test_seek_forward_none_position_does_not_raise(self) -> None:
+        """seek_forward must not raise when get_track_position() returns None."""
+        with patch.object(self.backend, "get_track_position", return_value=None), \
+                patch.object(self.backend, "set_track_position") as set_pos:
+            self.backend.seek_forward(1)  # should not raise TypeError
+            set_pos.assert_not_called()
+
+    def test_seek_backward_none_position_does_not_raise(self) -> None:
+        """seek_backward must not raise when get_track_position() returns None."""
+        with patch.object(self.backend, "get_track_position", return_value=None), \
+                patch.object(self.backend, "set_track_position") as set_pos:
+            self.backend.seek_backward(1)  # should not raise TypeError
+            set_pos.assert_not_called()
+
+    def test_ocp_start_reentry_does_not_double_emit(self) -> None:
+        """Calling ocp_start twice while already playing must not
+        re-emit PLAYING/LOADED_MEDIA/track.state a second time."""
+        self.backend._now_playing = "http://example.com/audio.mp3"
+        with patch.object(self.backend.bus, "emit") as emit_mock:
+            self.backend.ocp_start()
+            first_emit_count = emit_mock.call_count
+            self.assertGreater(first_emit_count, 0)
+
+            self.backend.ocp_start()  # re-entry: already LOADED/PLAYING
+            self.assertEqual(emit_mock.call_count, first_emit_count)
+
+    def test_ocp_start_after_stop_emits_again(self) -> None:
+        """ocp_start after an intervening ocp_stop must emit again."""
+        self.backend._now_playing = "http://example.com/audio.mp3"
+        with patch.object(self.backend.bus, "emit") as emit_mock:
+            self.backend.ocp_start()
+            first_emit_count = emit_mock.call_count
+            self.backend.ocp_stop()
+            self.backend._now_playing = "http://example.com/audio.mp3"
+            self.backend.ocp_start()
+            self.assertGreater(emit_mock.call_count, first_emit_count)
+
+    def test_ocp_start_after_load_track_emits_again(self) -> None:
+        """ocp_start after a new load_track must emit again."""
+        with patch.object(self.backend.bus, "emit") as emit_mock:
+            self.backend.load_track("http://example.com/a.mp3")
+            self.backend.ocp_start()
+            first_emit_count = emit_mock.call_count
+            self.backend.load_track("http://example.com/b.mp3")
+            self.backend.ocp_start()
+            self.assertGreater(emit_mock.call_count, first_emit_count)
+
+    def test_ocp_error_resets_ocp_playing(self) -> None:
+        """ocp_error clears the ocp_start idempotency guard."""
+        self.backend._now_playing = "http://example.com/audio.mp3"
+        self.backend.ocp_start()
+        self.assertTrue(self.backend._ocp_playing)
+        self.backend.ocp_error()
+        self.assertFalse(self.backend._ocp_playing)
+
+    def test_capability_flag_defaults(self) -> None:
+        """supports_seek and supports_pause default to True."""
+        self.assertTrue(self.backend.supports_seek)
+        self.assertTrue(self.backend.supports_pause)
+
     def test_set_track_start_callback(self) -> None:
         """set_track_start_callback stores the callback."""
         cb = MagicMock()

--- a/test/unittests/test_media_templates.py
+++ b/test/unittests/test_media_templates.py
@@ -277,6 +277,58 @@ class TestMediaBackend(unittest.TestCase):
         """seek_backward updates track position."""
         self.backend.seek_backward(1)  # get_track_position() - 1000ms
 
+    def test_seek_forward_none_position_does_not_raise(self) -> None:
+        """seek_forward must not raise when get_track_position() returns None."""
+        with patch.object(self.backend, "get_track_position", return_value=None), \
+                patch.object(self.backend, "set_track_position") as set_pos:
+            self.backend.seek_forward(1)  # should not raise TypeError
+            set_pos.assert_not_called()
+
+    def test_seek_backward_none_position_does_not_raise(self) -> None:
+        """seek_backward must not raise when get_track_position() returns None."""
+        with patch.object(self.backend, "get_track_position", return_value=None), \
+                patch.object(self.backend, "set_track_position") as set_pos:
+            self.backend.seek_backward(1)  # should not raise TypeError
+            set_pos.assert_not_called()
+
+    def test_ocp_start_reentry_does_not_double_play(self) -> None:
+        """Calling ocp_start twice while already playing must not call
+        play() twice nor re-emit LOADED_MEDIA/PLAYING a second time."""
+        self.backend._now_playing = "file:///test.mp3"
+        with patch.object(self.backend, "play") as play_mock, \
+                patch.object(self.backend.bus, "emit") as emit_mock:
+            self.backend.ocp_start()
+            self.assertEqual(play_mock.call_count, 1)
+            first_emit_count = emit_mock.call_count
+
+            self.backend.ocp_start()  # re-entry: already LOADED/PLAYING
+            self.assertEqual(play_mock.call_count, 1)
+            self.assertEqual(emit_mock.call_count, first_emit_count)
+
+    def test_ocp_start_after_stop_plays_again(self) -> None:
+        """ocp_start after an intervening ocp_stop must start playback again."""
+        self.backend._now_playing = "file:///test.mp3"
+        with patch.object(self.backend, "play") as play_mock:
+            self.backend.ocp_start()
+            self.backend.ocp_stop()
+            self.backend._now_playing = "file:///test.mp3"
+            self.backend.ocp_start()
+            self.assertEqual(play_mock.call_count, 2)
+
+    def test_ocp_start_after_load_track_plays_again(self) -> None:
+        """ocp_start after a new load_track must start playback again."""
+        with patch.object(self.backend, "play") as play_mock:
+            self.backend.load_track("file:///a.mp3")
+            self.backend.ocp_start()
+            self.backend.load_track("file:///b.mp3")
+            self.backend.ocp_start()
+            self.assertEqual(play_mock.call_count, 2)
+
+    def test_capability_flag_defaults(self) -> None:
+        """supports_seek and supports_pause default to True."""
+        self.assertTrue(self.backend.supports_seek)
+        self.assertTrue(self.backend.supports_pause)
+
     def test_track_info(self) -> None:
         """track_info returns meta dict."""
         self.backend.meta = {"artist": "Test Artist"}
@@ -309,6 +361,18 @@ class TestAudioPlayerBackend(unittest.TestCase):
         """ocp_start emits PLAYING_AUDIO track state."""
         self.backend._now_playing = "file:///test.mp3"
         self.backend.ocp_start()  # Should not raise
+
+    def test_ocp_start_reentry_does_not_double_emit_track_state(self) -> None:
+        """Re-entrant ocp_start on AudioPlayerBackend must not re-emit
+        PLAYING_AUDIO nor call play() again."""
+        self.backend._now_playing = "file:///test.mp3"
+        with patch.object(self.backend, "play") as play_mock, \
+                patch.object(self.backend.bus, "emit") as emit_mock:
+            self.backend.ocp_start()
+            count_after_first = emit_mock.call_count
+            self.backend.ocp_start()
+            self.assertEqual(play_mock.call_count, 1)
+            self.assertEqual(emit_mock.call_count, count_after_first)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This fixes three small defects in both backend templates, `ovos_plugin_manager/templates/media.py` (the class ovos-media backends subclass) and `ovos_plugin_manager/templates/audio.py` (the legacy class `ovos-audio-plugin-simple` and the ovos-audio daemon use). Some plugins ship one subclass of each, so the two hierarchies must behave the same.

`seek_forward` and `seek_backward` called `self.get_track_position() + ms` with no guard on the return value. A backend that legitimately has no track position yet (nothing loaded, a live stream, a backend still starting up) returns `None`, and the arithmetic raises `TypeError`. Both methods now check for `None`, log at debug level, and return without seeking.

`ocp_start` re-emitted `PLAYER.PLAYING` and `MEDIA.LOADED_MEDIA` and called `play()` again every time it was invoked, even if playback was already active. A caller that invokes `ocp_start` twice in a row — which does happen given the eventual consistency of bus messaging — would double-start playback. `ocp_start` is now idempotent: a `_ocp_playing` flag tracks whether playback is already active, and a re-entrant call is a no-op until `ocp_stop`, `ocp_error`, or a new `load_track` resets it. The `AudioPlayerBackend`/`VideoPlayerBackend`/`WebPlayerBackend` subclasses, which each emit an extra track-state message on top of the base call, were updated the same way so they don't double-emit either.

`MediaBackend` gains two class attributes, `supports_seek` and `supports_pause`, both defaulting to `True`. They're purely additive — existing plugins are unaffected — and let backends that genuinely can't seek or pause (a live stream, for instance) declare that so callers can check before calling.

ovos-media currently guards against all three of these at every call site that touches a backend. None of that guarding is removed here; this just makes the template itself correct, so those call-site guards become redundant rather than load-bearing, and can be simplified later without changing behavior.

Tests: added adversarial cases to `test/unittests/test_media_templates.py` covering a `None` position on both seek directions, re-entrant `ocp_start` (base class and `AudioPlayerBackend`), `ocp_start` resuming correctly after `ocp_stop` and after a new `load_track`, and the new capability-flag defaults. Every new test was confirmed to fail against the unfixed template (reverted via patch) and pass after the fix. Full existing suite: 969 passed, 3 pre-existing failures in `test_deprecation_noise.py` (unrelated — deprecation-warning counts for `solvers`/`OpenVoiceOSPlugin`, untouched by this change) unchanged before and after; `test_hardware.py`/`test_led_animations.py` skipped, missing the optional `ovos-hardware-helpers` dependency, also unrelated.

