### PR TITLE
docs: add prerelease-quirks entry for 2.11.1a3

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -1,0 +1,22 @@
+# Pre-release quirks
+
+Behavior changes since the last stable release, newest first. This file is
+reset at each stable release; entries that remove or deprecate behavior
+become the deprecation ledger for the next semver cycle.
+
+## 2.11.1a3
+
+- `UtteranceTransformersService.transform` and `MetadataTransformersService.transform`
+  no longer merge a transformer's returned context into itself. In-place
+  transformers commonly return the same context object they were handed;
+  merging that object into itself recursively walked identical nested
+  mappings until `RecursionError`. The merge is now skipped whenever the
+  returned object is the same object the transformer received, so caller
+  context identity is preserved, including an empty dict passed in by the
+  caller. A transformer that returns a distinct delta or replacement dict
+  still gets merged as before.
+- Debug logging in the transformer runners is gated behind a check of the
+  active log level and uses lazy `%s` formatting, avoiding the cost of
+  building a debug string when debug logging is disabled. The logged
+  context is also redacted: the `session` key is stripped before logging
+  because a serialized session can carry credentials.


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Adds a `docs/prerelease-quirks.md` file for this repo, following the convention already used elsewhere, and records the behavior change in the just-released 2.11.1a3: `UtteranceTransformersService` and `MetadataTransformersService` no longer merge a transformer's returned context into itself when the transformer hands back the same object it received, which previously produced a `RecursionError` on nested self-returned contexts and lost caller context identity for an empty dict.

The entry also notes that transformer debug logging is now gated behind an active-debug-level check and strips the `session` key from the logged context before emitting it.

README.md and docs/transformers.md were checked for claims contradicted by this change; none were found, so no other files were touched.
