### PR TITLE
fix: allow ovos-config 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ovos-utils>=0.2.1,<1.0.0",
     "ovos_bus_client>=0.0.8,<3.0.0",
-    "ovos-config>=0.0.12,<3.0.0",
+    "ovos-config>=0.0.12,<4.0.0",
     "combo_lock~=0.3",
     "requests~=2.32",
     "quebra_frases",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-config 3.0.0a1 is a breaking release that introduces AssistantConfig and removes the remote-config APIs. An adversarial sweep of this repo found no use of any API that was removed in that release, so the `<3.0.0` upper bound on the `ovos-config` dependency only blocks a compatible upgrade without protecting against any real incompatibility.

This raises the cap to `<4.0.0`, keeping the existing floor. Normal resolution still lands on ovos-config 2.x because the PyPI release of ovos-bus-client still caps ovos-config below 3.0.0 (that cap-lift is a separate draft PR). Forcing `ovos-config==3.0.1a1` and running the full suite against it gives 1033 passed and 49 skipped, with no failures.

Merge after ovos-config 3.0.1a1: 3.0.0a1 is missing follow-up hardening that ships in 3.0.1a1.