### PR TITLE
fix: PHALPlugin.shutdown() removes the handlers it actually registered

### DIFF
--- a/docs/prerelease-quirks.md
+++ b/docs/prerelease-quirks.md
@@ -4,6 +4,21 @@ Behavior changes since the last stable release, newest first. This file is
 reset at each stable release; entries that remove or deprecate behavior
 become the deprecation ledger for the next semver cycle.
 
+## 2.11.4a2
+
+- `PHALPlugin.shutdown()` now removes exactly the `(topic, handler)` pairs
+  the instance registered, tracked in a list appended to by every call
+  through a new `_on()` wrapper used in `register_core_events()` and
+  `register_enclosure_namespace()`. Previously `shutdown()` called
+  `bus.remove(topic, <handler>)` with a hardcoded handler that in several
+  cases (`enclosure.mouth.talk`, `.think`, `.listen`, `.smile`, `.viseme`,
+  and `enclosure.eyes.level`, whose removal used the wrong topic name
+  `enclosure.eyes.brightness`) did not match the callable actually passed to
+  `bus.on()`, and `recognizer_loop:audio_output_end` was never removed at
+  all. Since bus listener removal is an identity check, those handlers kept
+  firing after a plugin was shut down or reloaded. A shut-down `PHALPlugin`
+  now stops reacting to every event it registered for.
+
 ## 2.11.2a2
 
 - Plugin entry-point discovery now imports `entry_points` from the standard

--- a/ovos_plugin_manager/templates/phal.py
+++ b/ovos_plugin_manager/templates/phal.py
@@ -42,6 +42,7 @@ class PHALPlugin(Thread):
         self.bus = bus or get_mycroft_bus()
         self.log = LOG
         self.name = name
+        self._registered_handlers = []
 
         self.register_enclosure_namespace()
         self.register_core_events()
@@ -49,56 +50,62 @@ class PHALPlugin(Thread):
         self._activate_mouth_events()
         self.start()
 
+    def _on(self, topic, handler):
+        """Register a bus handler and remember it so `shutdown` can remove
+        the exact (topic, handler) pair it registered."""
+        self.bus.on(topic, handler)
+        self._registered_handlers.append((topic, handler))
+
     def register_core_events(self):
         # audio events
-        self.bus.on('recognizer_loop:record_begin', self.on_record_begin)
-        self.bus.on('recognizer_loop:record_end', self.on_record_end)
-        self.bus.on("recognizer_loop:sleep", self.on_sleep)
-        self.bus.on('recognizer_loop:audio_output_start', self.on_audio_output_start)
-        self.bus.on('recognizer_loop:audio_output_end', self.on_audio_output_end)
-        self.bus.on("mycroft.awoken", self.on_awake)
-        self.bus.on("speak", self.on_speak)
+        self._on('recognizer_loop:record_begin', self.on_record_begin)
+        self._on('recognizer_loop:record_end', self.on_record_end)
+        self._on("recognizer_loop:sleep", self.on_sleep)
+        self._on('recognizer_loop:audio_output_start', self.on_audio_output_start)
+        self._on('recognizer_loop:audio_output_end', self.on_audio_output_end)
+        self._on("mycroft.awoken", self.on_awake)
+        self._on("speak", self.on_speak)
 
     def register_enclosure_namespace(self):
-        self.bus.on("enclosure.notify.no_internet", self.on_no_internet)
-        self.bus.on("enclosure.reset", self.on_reset)
+        self._on("enclosure.notify.no_internet", self.on_no_internet)
+        self._on("enclosure.reset", self.on_reset)
 
         # enclosure commands for OpenVoiceOS's Hardware.
-        self.bus.on("enclosure.system.reset", self.on_system_reset)
-        self.bus.on("enclosure.system.mute", self.on_system_mute)
-        self.bus.on("enclosure.system.unmute", self.on_system_unmute)
-        self.bus.on("enclosure.system.blink", self.on_system_blink)
+        self._on("enclosure.system.reset", self.on_system_reset)
+        self._on("enclosure.system.mute", self.on_system_mute)
+        self._on("enclosure.system.unmute", self.on_system_unmute)
+        self._on("enclosure.system.blink", self.on_system_blink)
 
         # enclosure commands for eyes
-        self.bus.on('enclosure.eyes.on', self.on_eyes_on)
-        self.bus.on('enclosure.eyes.off', self.on_eyes_off)
-        self.bus.on('enclosure.eyes.blink', self.on_eyes_blink)
-        self.bus.on('enclosure.eyes.narrow', self.on_eyes_narrow)
-        self.bus.on('enclosure.eyes.look', self.on_eyes_look)
-        self.bus.on('enclosure.eyes.color', self.on_eyes_color)
-        self.bus.on('enclosure.eyes.level', self.on_eyes_brightness)
-        self.bus.on('enclosure.eyes.volume', self.on_eyes_volume)
-        self.bus.on('enclosure.eyes.spin', self.on_eyes_spin)
-        self.bus.on('enclosure.eyes.timedspin', self.on_eyes_timed_spin)
-        self.bus.on('enclosure.eyes.reset', self.on_eyes_reset)
-        self.bus.on('enclosure.eyes.setpixel', self.on_eyes_set_pixel)
-        self.bus.on('enclosure.eyes.fill', self.on_eyes_fill)
+        self._on('enclosure.eyes.on', self.on_eyes_on)
+        self._on('enclosure.eyes.off', self.on_eyes_off)
+        self._on('enclosure.eyes.blink', self.on_eyes_blink)
+        self._on('enclosure.eyes.narrow', self.on_eyes_narrow)
+        self._on('enclosure.eyes.look', self.on_eyes_look)
+        self._on('enclosure.eyes.color', self.on_eyes_color)
+        self._on('enclosure.eyes.level', self.on_eyes_brightness)
+        self._on('enclosure.eyes.volume', self.on_eyes_volume)
+        self._on('enclosure.eyes.spin', self.on_eyes_spin)
+        self._on('enclosure.eyes.timedspin', self.on_eyes_timed_spin)
+        self._on('enclosure.eyes.reset', self.on_eyes_reset)
+        self._on('enclosure.eyes.setpixel', self.on_eyes_set_pixel)
+        self._on('enclosure.eyes.fill', self.on_eyes_fill)
 
         # enclosure commands for mouth
-        self.bus.on("enclosure.mouth.events.activate", self._activate_mouth_events)
-        self.bus.on("enclosure.mouth.events.deactivate", self._deactivate_mouth_events)
-        self.bus.on("enclosure.mouth.talk", self._on_mouth_talk)
-        self.bus.on("enclosure.mouth.think", self._on_mouth_think)
-        self.bus.on("enclosure.mouth.listen", self._on_mouth_listen)
-        self.bus.on("enclosure.mouth.smile", self._on_mouth_smile)
-        self.bus.on("enclosure.mouth.viseme", self._on_mouth_viseme)
-        self.bus.on("enclosure.mouth.viseme_list", self._on_mouth_viseme_list)
+        self._on("enclosure.mouth.events.activate", self._activate_mouth_events)
+        self._on("enclosure.mouth.events.deactivate", self._deactivate_mouth_events)
+        self._on("enclosure.mouth.talk", self._on_mouth_talk)
+        self._on("enclosure.mouth.think", self._on_mouth_think)
+        self._on("enclosure.mouth.listen", self._on_mouth_listen)
+        self._on("enclosure.mouth.smile", self._on_mouth_smile)
+        self._on("enclosure.mouth.viseme", self._on_mouth_viseme)
+        self._on("enclosure.mouth.viseme_list", self._on_mouth_viseme_list)
 
         # mouth/matrix display
-        self.bus.on("enclosure.mouth.reset", self.on_display_reset)
-        self.bus.on("enclosure.mouth.text", self.on_text)
-        self.bus.on("enclosure.mouth.display", self.on_display)
-        self.bus.on("enclosure.weather.display", self.on_weather_display)
+        self._on("enclosure.mouth.reset", self.on_display_reset)
+        self._on("enclosure.mouth.text", self.on_text)
+        self._on("enclosure.mouth.display", self.on_display)
+        self._on("enclosure.weather.display", self.on_weather_display)
 
 
     @classproperty
@@ -131,47 +138,9 @@ class PHALPlugin(Thread):
         self.bus.emit(Message(f"{skill_id}.{msg_type}", msg_data, {"skill_id": skill_id}))
 
     def shutdown(self):
-        self.bus.remove("enclosure.reset", self.on_reset)
-        self.bus.remove("enclosure.system.reset", self.on_system_reset)
-        self.bus.remove("enclosure.system.mute", self.on_system_mute)
-        self.bus.remove("enclosure.system.unmute", self.on_system_unmute)
-        self.bus.remove("enclosure.system.blink", self.on_system_blink)
-
-        self.bus.remove("enclosure.eyes.on", self.on_eyes_on)
-        self.bus.remove("enclosure.eyes.off", self.on_eyes_off)
-        self.bus.remove("enclosure.eyes.blink", self.on_eyes_blink)
-        self.bus.remove("enclosure.eyes.narrow", self.on_eyes_narrow)
-        self.bus.remove("enclosure.eyes.look", self.on_eyes_look)
-        self.bus.remove("enclosure.eyes.color", self.on_eyes_color)
-        self.bus.remove("enclosure.eyes.brightness", self.on_eyes_brightness)
-        self.bus.remove("enclosure.eyes.reset", self.on_eyes_reset)
-        self.bus.remove("enclosure.eyes.timedspin", self.on_eyes_timed_spin)
-        self.bus.remove("enclosure.eyes.volume", self.on_eyes_volume)
-        self.bus.remove("enclosure.eyes.spin", self.on_eyes_spin)
-        self.bus.remove("enclosure.eyes.setpixel", self.on_eyes_set_pixel)
-        self.bus.remove('enclosure.eyes.fill', self.on_eyes_fill)
-
-        self.bus.remove("enclosure.mouth.reset", self.on_display_reset)
-        self.bus.remove("enclosure.mouth.talk", self.on_talk)
-        self.bus.remove("enclosure.mouth.think", self.on_think)
-        self.bus.remove("enclosure.mouth.listen", self.on_listen)
-        self.bus.remove("enclosure.mouth.smile", self.on_smile)
-        self.bus.remove("enclosure.mouth.viseme", self.on_viseme)
-        self.bus.remove("enclosure.mouth.viseme_list", self._on_mouth_viseme_list)
-        self.bus.remove("enclosure.mouth.text", self.on_text)
-        self.bus.remove("enclosure.mouth.display", self.on_display)
-        self.bus.remove("enclosure.mouth.events.activate", self._activate_mouth_events)
-        self.bus.remove("enclosure.mouth.events.deactivate", self._deactivate_mouth_events)
-
-        self.bus.remove("enclosure.weather.display", self.on_weather_display)
-
-        self.bus.remove("mycroft.awoken", self.on_awake)
-        self.bus.remove("recognizer_loop:sleep", self.on_sleep)
-        self.bus.remove("speak", self.on_speak)
-        self.bus.remove('recognizer_loop:record_begin', self.on_record_begin)
-        self.bus.remove('recognizer_loop:record_end', self.on_record_end)
-        self.bus.remove('recognizer_loop:audio_output_start', self.on_audio_output_start)
-        self.bus.remove("enclosure.notify.no_internet", self.on_no_internet)
+        for topic, handler in self._registered_handlers:
+            self.bus.remove(topic, handler)
+        self._registered_handlers = []
 
         self._deactivate_mouth_events()
         self._running = False

--- a/test/unittests/test_phal_shutdown_handlers.py
+++ b/test/unittests/test_phal_shutdown_handlers.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+
+class TestPHALShutdownHandlerLeak(unittest.TestCase):
+    """Regression tests for PHALPlugin.shutdown() removing exactly the
+    handlers it registered on the bus.
+
+    Previously `shutdown()` called `bus.remove(topic, <handler>)` with a
+    hardcoded handler that in several cases did not match the callable
+    actually passed to `bus.on()` in `register_enclosure_namespace()` /
+    `register_core_events()` (e.g. "enclosure.mouth.talk" was registered
+    with `_on_mouth_talk` but removed with `on_talk`), and
+    "recognizer_loop:audio_output_end" was registered but never removed at
+    all. Since bus listener removal is an identity check on the handler,
+    those listeners survived `shutdown()` and kept reacting to events.
+    """
+
+    @patch("ovos_plugin_manager.templates.phal.Configuration", return_value={})
+    def _make_plugin(self, mock_cfg, bus, name="test-phal"):
+        from ovos_plugin_manager.templates.phal import PHALPlugin
+        with patch.object(PHALPlugin, "start"):
+            plugin = PHALPlugin(bus=bus, name=name, config={})
+        return plugin
+
+    def test_shutdown_removes_every_registered_listener(self):
+        bus = FakeBus()
+        plugin = self._make_plugin(bus=bus)
+
+        self.assertTrue(len(plugin._registered_handlers) > 0)
+        for topic, _handler in plugin._registered_handlers:
+            self.assertGreaterEqual(len(bus.ee.listeners(topic)), 1,
+                                     f"handler for {topic} was not registered on the bus")
+
+        plugin.shutdown()
+
+        for topic, _handler in plugin._registered_handlers:
+            self.assertEqual(len(bus.ee.listeners(topic)), 0,
+                              f"a listener for {topic} survived shutdown()")
+
+    def test_shutdown_stops_dispatch_for_named_signatures(self):
+        # the two topics explicitly called out as broken: a mismatched
+        # handler pair (mouth.talk) and a topic missing from shutdown
+        # entirely (audio_output_end)
+        from ovos_plugin_manager.templates.phal import PHALPlugin
+        bus = FakeBus()
+        with patch.object(PHALPlugin, "on_talk") as mock_talk, \
+                patch.object(PHALPlugin, "on_audio_output_end") as mock_end:
+            plugin = self._make_plugin(bus=bus)
+
+            bus.emit(Message("enclosure.mouth.talk"))
+            bus.emit(Message("recognizer_loop:audio_output_end"))
+            self.assertTrue(mock_talk.called)
+            self.assertTrue(mock_end.called)
+            mock_talk.reset_mock()
+            mock_end.reset_mock()
+
+            plugin.shutdown()
+
+            bus.emit(Message("enclosure.mouth.talk"))
+            bus.emit(Message("recognizer_loop:audio_output_end"))
+            self.assertFalse(mock_talk.called,
+                              "on_talk still fires after shutdown()")
+            self.assertFalse(mock_end.called,
+                              "on_audio_output_end still fires after shutdown()")
+
+    def test_shutdown_does_not_affect_other_instance(self):
+        bus = FakeBus()
+        plugin_a = self._make_plugin(bus=bus, name="phal-a")
+        plugin_b = self._make_plugin(bus=bus, name="phal-b")
+
+        counts_before = {topic: len(bus.ee.listeners(topic))
+                          for topic, _h in plugin_b._registered_handlers}
+
+        plugin_a.shutdown()
+
+        for topic, _handler in plugin_b._registered_handlers:
+            # plugin_a's own listener for this shared topic is gone, but
+            # plugin_b's must still be there
+            self.assertEqual(len(bus.ee.listeners(topic)), counts_before[topic] - 1,
+                              f"shutting down plugin_a removed plugin_b's "
+                              f"listener for {topic}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

A docs-audit pass reproduced a handler leak in `ovos_plugin_manager/templates/phal.py`: `PHALPlugin.register_enclosure_namespace()` and `register_core_events()` subscribe a set of bound methods to bus topics, but `shutdown()` calls `bus.remove(topic, <handler>)` with a separately hand-maintained list that in several places names a different callable than the one actually registered. Bus listener removal is an identity check on the handler object, so any mismatch means the original listener is never removed.

The concrete mismatches confirmed against `origin/dev`: `enclosure.mouth.talk` is registered with `_on_mouth_talk` but `shutdown()` removes `on_talk`; the same pattern repeats for `.think` (`_on_mouth_think` vs `on_think`), `.listen` (`_on_mouth_listen` vs `on_listen`), `.smile` (`_on_mouth_smile` vs `on_smile`), and `.viseme` (`_on_mouth_viseme` vs `on_viseme`). `enclosure.eyes.level` is registered with `on_eyes_brightness`, but `shutdown()` tries to remove it under the topic `enclosure.eyes.brightness`, which was never registered, so that handler is untouched too. Finally `recognizer_loop:audio_output_end` is registered in `register_core_events()` but has no corresponding `bus.remove()` call in `shutdown()` at all (only its sibling `audio_output_start` is removed). The net effect is that a shut-down or reloaded PHAL plugin keeps reacting to enclosure and recognizer_loop events indefinitely.

The fix replaces the hand-maintained removal list with bookkeeping: a small `_on(topic, handler)` wrapper is used everywhere `register_core_events()` and `register_enclosure_namespace()` call `bus.on()`, appending each `(topic, handler)` pair to `self._registered_handlers`. `shutdown()` now iterates that list and removes exactly those pairs, then clears it, before running the existing `_deactivate_mouth_events()` / `_running = False` cleanup. No other behavior or the enclosure API itself was touched; a broader refactor of that API is tracked separately.

`test/unittests/test_phal_shutdown_handlers.py` adds three FakeBus-based tests: one asserts every `(topic, handler)` pair the instance registered has zero bus listeners after `shutdown()`, one behaviorally checks the two named broken signatures (`enclosure.mouth.talk` and `recognizer_loop:audio_output_end`) by mocking the handler methods and confirming they stop firing after shutdown, and one confirms shutting down one instance leaves a second instance's handlers on the same bus intact. All three tests were verified to fail against the unfixed source (source-only patch revert, test kept): the audio_output_end mock's `.called` was `True` after `shutdown()`, and the other two failed on the missing `_registered_handlers` bookkeeping the fix introduces. After restoring the fix all three pass, and the full suite runs at 1036 passed, 49 skipped with no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed plugin shutdown so all event listeners are reliably removed.
  - Prevented enclosure and audio-output events from continuing to trigger after shutdown or reload.
  - Ensured multiple plugin instances clean up only their own listeners.

- **Documentation**
  - Added a pre-release changelog entry describing the shutdown listener cleanup improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->