### PR TITLE
feat!: MediaBackend v2 - plugins report events, the daemon owns all state emission

### DIFF
--- a/ovos_plugin_manager/templates/media.py
+++ b/ovos_plugin_manager/templates/media.py
@@ -1,91 +1,173 @@
+import enum
 from abc import ABCMeta, abstractmethod
+from typing import Callable, Optional
 
-from ovos_bus_client.message import Message
-from ovos_utils.log import LOG
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.ocp import MediaState, PlayerState, TrackState
+from ovos_utils.log import LOG
+
+
+class PlaybackEvent(enum.Enum):
+    """Physical playback events a MediaBackend plugin can observe.
+
+    These describe what actually happened inside the player process:
+    a track started, playback paused/resumed/stopped, the media ended,
+    or the player errored out. There is no "loaded" event here - loading
+    is reported through ``load_track``'s return value, and turning that
+    into a state transition (and any wire message) is the daemon's job,
+    not the plugin's.
+    """
+    TRACK_START = "track_start"
+    PAUSED = "paused"
+    RESUMED = "resumed"
+    STOPPED = "stopped"
+    END_OF_MEDIA = "end_of_media"
+    ERROR = "error"
+    """Reported as ``report(PlaybackEvent.ERROR, error=str(exc))`` - the
+    ``error`` kwarg is the normative payload key and its value is always a
+    string description of what went wrong."""
 
 
 class MediaBackend(metaclass=ABCMeta):
     """Base class for all OCP media backend implementations.
 
-    Media backends are single-track, playlists are handled by OCP
+    Media backends are single-track, playlists are handled by OCP.
 
-   Arguments:
-       config (dict): configuration dict for the instance
-       bus (MessageBusClient): Mycroft messagebus emitter
-   """
+    ``self.bus`` is a plugin-private transport, not a state channel. Use it
+    for whatever ecosystem integration or plugin-private protocol the
+    backend needs - e.g. a discovery announcement like
+    ovos-media-plugin-mass's ``ovos.mass.ping`` - never to report playback
+    state. Playback state flows exclusively through ``report``/
+    ``bind_event_reporter``: the physical events the plugin observes
+    (track started, paused, resumed, stopped, ended, errored). The daemon
+    that owns the plugin is the only thing that translates those physical
+    events into bus messages and drives the player state machine -
+    including the LOADED_MEDIA transition, which is bookkeeping on
+    ``load_track``'s return value and therefore not a ``PlaybackEvent``. A
+    backend that emits any ``ovos.common_play.*`` state message itself is
+    buggy by definition - the daemon owns that wire.
+
+    Subprocess-shaped backends (anything wrapping an external player
+    binary): a player process exiting with a nonzero return code is an
+    ``ERROR``, never an ``END_OF_MEDIA``. Check the return code in the
+    exit callback before calling ``report_track_end`` - a subprocess that
+    dies because the file doesn't exist and one that finishes playing
+    cleanly both look like "the process exited" to a naive callback, and
+    only the return code tells them apart.
+
+    Remote/side-channel backends (Cast, MPRIS, network players): the verb
+    methods (``play``/``pause``/``resume``/``stop``) SHOULD be pure asks
+    with zero ``report()`` calls of their own - asking a remote player to
+    pause does not mean it *will* pause. The status listener or poller
+    that watches the remote player's actual state is the sole reporter of
+    what happened, so a change made outside OVOS entirely (a user pausing
+    from the device's own app) still surfaces correctly as a
+    ``PAUSED``/``RESUMED``/``STOPPED`` report.
+
+    External-state detection may be event-driven (native signals or
+    listener callbacks from the remote player's own SDK - preferred where
+    available) or polled state-diffing (acceptable when no event exists:
+    compare the freshly-polled state against the last seen state and
+    report only the transition, not the polled state itself).
+
+    Arguments:
+        config (dict): configuration dict for the instance
+        bus (MessageBusClient): plugin-private messagebus connection, for
+            non-state ecosystem integration only. Defaults to a FakeBus
+            when not provided, so a backend is always safe to construct
+            and drive standalone (e.g. in tests) without a real bus.
+    """
+
+    can_seek: bool = False
+    can_pause: bool = True
+    is_remote: bool = False
 
     def __init__(self, config=None, bus=None):
-        if MediaState is None:
-            raise RuntimeError("Please update to ovos-utils~=0.1.")
-        self._now_playing = None  # single uri
-        self._track_start_callback = None
         self.supports_mime_hints = False
         self.config = config or {}
         self.bus = bus or FakeBus()
         self.meta = {}
+        self._event_reporter: Optional[Callable[..., None]] = None
+        self._stop_requested = False
 
-    def set_track_start_callback(self, callback_func):
-        """Register callback on track start.
+    def bind_event_reporter(self, reporter: Callable[..., None]) -> None:
+        """Register the callable the daemon uses to receive playback events.
 
-        This method should be called as each track in a playlist is started.
+        The normative call signature is ``reporter(event, **data)``: the
+        reporter is always called positionally with a ``PlaybackEvent`` as
+        the first argument, followed by event-specific data as keyword
+        arguments (e.g. ``error=str(exc)`` for ``PlaybackEvent.ERROR``).
+        A reporter may declare ``**kwargs`` to accept any event, or name
+        only the specific keywords it cares about.
+
+        Arguments:
+            reporter: callable invoked as ``reporter(event, **data)`` every
+                time the plugin observes a physical playback event.
         """
-        self._track_start_callback = callback_func
+        self._event_reporter = reporter
 
-    def load_track(self, uri: str, metadata: dict = None):
-        self._now_playing = uri
-        self.meta.update(metadata or {})
-        LOG.debug(f"queuing for {self.__class__.__name__} playback: {uri}")
-        self.bus.emit(Message("ovos.common_play.media.state",
-                              {"state": MediaState.LOADED_MEDIA}))
+    def report(self, event: PlaybackEvent, **data) -> None:
+        """Report a physical playback event to the daemon, if bound.
 
-    def ocp_start(self):
-        """Emit OCP status events for play"""
-        self.bus.emit(Message("ovos.common_play.player.state",
-                              {"state": PlayerState.PLAYING}))
-        self.bus.emit(Message("ovos.common_play.media.state",
-                              {"state": MediaState.LOADED_MEDIA}))
-        self.play()
+        Always calls the bound reporter as ``reporter(event, **data)`` -
+        see ``bind_event_reporter`` for the normative signature. No-ops
+        (with a debug log) when no reporter has been registered, so
+        backends can be constructed and exercised standalone, e.g. in
+        tests, without a daemon attached.
 
-    def ocp_error(self):
-        """Emit OCP status events for playback error"""
-        if self._now_playing:
-            self._now_playing = None
-            self.bus.emit(Message("ovos.common_play.media.state",
-                                  {"state": MediaState.INVALID_MEDIA}))
-            self.bus.emit(Message("ovos.common_play.player.state",
-                                  {"state": PlayerState.STOPPED}))
+        Plugins SHOULD attach the ``uri`` of the track the event belongs
+        to when reporting ``PlaybackEvent.END_OF_MEDIA`` and
+        ``PlaybackEvent.ERROR`` - ``self.report(PlaybackEvent.END_OF_MEDIA,
+        uri=<the uri load_track received>)`` - so the daemon can detect and
+        drop a stale event that outlives its track (e.g. a late callback
+        from a previous track's watcher thread firing after a new track
+        has already loaded). An event reported without a ``uri`` cannot be
+        staleness-checked by the daemon.
+        """
+        if self._event_reporter is None:
+            LOG.debug(f"{self.__class__.__name__} not bound to an event "
+                      f"reporter, dropping {event}")
+            return
+        self._event_reporter(event, **data)
 
-    def ocp_stop(self):
-        """Emit OCP status events for stop"""
-        if self._now_playing:
-            self._now_playing = None
-            self.bus.emit(Message("ovos.common_play.player.state",
-                                  {"state": PlayerState.STOPPED}))
-            self.bus.emit(Message("ovos.common_play.media.state",
-                                  {"state": MediaState.END_OF_MEDIA}))
-            self.stop()
+    def report_track_end(self, uri: str = None, error=None) -> None:
+        """Report that a track ended, from a callback that cannot itself
+        tell a requested stop from a natural end.
 
-    def ocp_pause(self):
-        """Emit OCP status events for pause"""
-        if self._now_playing:
-            self.bus.emit(Message("ovos.common_play.player.state",
-                                  {"state": PlayerState.PAUSED}))
-            self.pause()
+        This is THE way to report the end of a track from an exit/status
+        callback that only sees "playback is no longer happening" -
+        e.g. a subprocess exit handler, or an MPRIS ``Stopped`` transition
+        - and has no other way to know whether OVOS asked for the stop or
+        the track simply finished on its own.
 
-    def ocp_resume(self):
-        """Emit OCP status events for resume"""
-        if self._now_playing:
-            self.bus.emit(Message("ovos.common_play.player.state",
-                                  {"state": PlayerState.PLAYING}))
-            self.bus.emit(Message("ovos.common_play.track.state",
-                                  {"state": TrackState.PLAYING_AUDIO}))
-            self.resume()
+        Dispatches based on why playback ended:
 
-    @property
-    def playback_time(self):
-        return 0
+        - ``error`` is not None: reports ``PlaybackEvent.ERROR`` with
+          ``error=str(error)``. A nonzero subprocess exit code or an
+          engine-reported failure MUST be passed here - it must never be
+          mapped to a natural end just because the process/session exited.
+        - ``error`` is None and ``stop()`` was called since the last
+          report: reports ``PlaybackEvent.STOPPED``.
+        - otherwise: reports ``PlaybackEvent.END_OF_MEDIA``.
+
+        Always clears the pending explicit-stop flag afterward, whichever
+        branch was taken, so the next end-of-track callback starts clean.
+
+        Arguments:
+            uri: the uri of the track this end-of-playback event belongs
+                to, forwarded to ``report`` for daemon-side staleness
+                checks (see ``report``).
+            error: the exception or error description if playback ended
+                because of a failure, else None.
+        """
+        try:
+            if error is not None:
+                self.report(PlaybackEvent.ERROR, error=str(error), uri=uri)
+            elif self._stop_requested:
+                self.report(PlaybackEvent.STOPPED, uri=uri)
+            else:
+                self.report(PlaybackEvent.END_OF_MEDIA, uri=uri)
+        finally:
+            self._stop_requested = False
 
     @abstractmethod
     def supported_uris(self):
@@ -96,18 +178,48 @@ class MediaBackend(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def play(self):
-        """Start playback.
+    def load_track(self, uri: str, metadata: dict = None) -> bool:
+        """Load a track for playback.
 
-        Starts playing the first track in the playlist and will contiune
-        until all tracks have been played.
+        Reports nothing - this only signals success/failure of loading.
+        The daemon owns the LOADED_MEDIA state transition on a True return.
+
+        Arguments:
+            uri (str): uri to load
+            metadata (dict): track metadata
+
+        Returns:
+            bool: True if the track was loaded successfully
         """
 
     @abstractmethod
-    def stop(self):
+    def play(self):
+        """Start playback.
+
+        Starts playing the loaded track.
+        """
+
+    def stop(self) -> bool:
         """Stop playback.
 
-        Stops the current playback.
+        Concrete template method: records that a stop was explicitly
+        requested (so a subsequent ``report_track_end`` from an exit/
+        status callback can tell this apart from a natural end), then
+        delegates to ``_stop`` for the actual work. Plugins implement
+        ``_stop``, not ``stop``.
+
+        Returns:
+            bool: True if playback was stopped, otherwise False
+        """
+        self._stop_requested = True
+        return self._stop()
+
+    @abstractmethod
+    def _stop(self) -> bool:
+        """Perform the actual stop.
+
+        Called by ``stop()`` after it has recorded the explicit-stop flag.
+        Implement this, not ``stop``, in backends.
 
         Returns:
             bool: True if playback was stopped, otherwise False
@@ -118,7 +230,7 @@ class MediaBackend(metaclass=ABCMeta):
         """Pause playback.
 
         Stops playback but may be resumed at the exact position the pause
-        occured.
+        occurred.
         """
 
     @abstractmethod
@@ -128,62 +240,56 @@ class MediaBackend(metaclass=ABCMeta):
         Resumes playback after being paused.
         """
 
-    @abstractmethod
     def lower_volume(self):
         """Lower volume.
 
-        This method is used to implement audio ducking. It will be called when
-        OpenVoiceOS is listening or speaking to make sure the media playing isn't
-        interfering.
+        Used to implement audio ducking. Called when OpenVoiceOS is
+        listening or speaking to make sure the media playing isn't
+        interfering. No-op by default.
         """
 
-    @abstractmethod
     def restore_volume(self):
         """Restore normal volume.
 
-        Called when to restore the playback volume to previous level after
-        OpenVoiceOS has lowered it using lower_volume().
+        Called to restore the playback volume to its previous level after
+        OpenVoiceOS has lowered it using ``lower_volume``. No-op by default.
         """
 
-    @abstractmethod
     def get_track_length(self) -> int:
         """
-        getting the duration of the audio in milliseconds
-        """
+        Get the duration of the current track in milliseconds.
 
-    @abstractmethod
+        Concrete default returns -1 (unknown), since ``can_seek`` defaults
+        to False and a backend that can't seek has no reason to track
+        duration. Backends that support seeking should override this,
+        return a real value, and set ``can_seek = True``.
+        """
+        return -1
+
     def get_track_position(self) -> int:
         """
-        get current position in milliseconds
-        """
+        Get current playback position in milliseconds.
 
-    @abstractmethod
-    def set_track_position(self, milliseconds):
+        Concrete default returns -1 (unknown); see ``get_track_length``.
+        Backends that support seeking should override this and set
+        ``can_seek = True``.
         """
-        go to position in milliseconds
+        return -1
+
+    def set_track_position(self, milliseconds: int):
+        """
+        Seek to a position in milliseconds.
+
+        Concrete default is a no-op (with a debug log); it is only
+        meaningful when ``can_seek`` is True. Backends that support
+        seeking should override this, perform the seek, and set
+        ``can_seek = True``.
+
           Args:
                 milliseconds (int): number of milliseconds of final position
         """
-
-    def seek_forward(self, seconds=1):
-        """Skip X seconds.
-
-        Arguments:
-            seconds (int): number of seconds to seek, if negative rewind
-        """
-        miliseconds = seconds * 1000
-        new_pos = self.get_track_position() + miliseconds
-        self.set_track_position(new_pos)
-
-    def seek_backward(self, seconds=1):
-        """Rewind X seconds.
-
-        Arguments:
-            seconds (int): number of seconds to seek, if negative jump forward.
-        """
-        miliseconds = seconds * 1000
-        new_pos = self.get_track_position() - miliseconds
-        self.set_track_position(new_pos)
+        LOG.debug(f"{self.__class__.__name__} does not support seeking "
+                  f"(can_seek=False), ignoring set_track_position({milliseconds})")
 
     def track_info(self):
         """Get info about current playing track.
@@ -196,24 +302,13 @@ class MediaBackend(metaclass=ABCMeta):
     def shutdown(self):
         """Perform clean shutdown.
 
-        Implements any audio backend specific shutdown procedures.
+        Implements any media backend specific shutdown procedures.
         """
         self.stop()
 
 
 class AudioPlayerBackend(MediaBackend):
     """ for audio"""
-
-    def load_track(self, uri, metadata: dict = None):
-        super().load_track(uri, metadata)
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.QUEUED_AUDIO}))
-
-    def ocp_start(self):
-        """Emit OCP status events for play"""
-        super().ocp_start()
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.PLAYING_AUDIO}))
 
 
 class RemoteAudioPlayerBackend(AudioPlayerBackend):
@@ -224,53 +319,35 @@ class RemoteAudioPlayerBackend(AudioPlayerBackend):
 
     An example of a RemoteAudioBackend would be things like mopidy servers, etc.
     """
+    is_remote = True
 
 
 class VideoPlayerBackend(MediaBackend):
     """ for video"""
-    def load_track(self, uri, metadata: dict = None):
-        super().load_track(uri, metadata)
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.QUEUED_VIDEO}))
-
-    def ocp_start(self):
-        """Emit OCP status events for play"""
-        super().ocp_start()
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.PLAYING_VIDEO}))
 
 
 class RemoteVideoPlayerBackend(VideoPlayerBackend):
-    """Base class for remote audio backends.
+    """Base class for remote video backends.
 
     RemoteVideoBackends will always be checked after the normal
     VideoBackends to make playback start locally by default.
 
     An example of a RemoteVideoBackend would be things like Chromecasts, etc.
     """
+    is_remote = True
 
 
 class WebPlayerBackend(MediaBackend):
     """ for web pages"""
-
-    def load_track(self, uri, metadata: dict = None):
-        super().load_track(uri, metadata)
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.QUEUED_WEBVIEW}))
-
-    def ocp_start(self):
-        """Emit OCP status events for play"""
-        super().ocp_start()
-        self.bus.emit(Message("ovos.common_play.track.state",
-                              {"state": TrackState.PLAYING_WEBVIEW}))
 
 
 class RemoteWebPlayerBackend(WebPlayerBackend):
     """Base class for remote web backends.
 
     RemoteWebBackends will always be checked after the normal
-    VideoBackends to make playback start locally by default.
+    WebBackends to make playback start locally by default.
 
     An example of a RemoteWebBackend would be
     things that can render a webpage in a different machine
     """
+    is_remote = True

--- a/test/unittests/test_media_templates.py
+++ b/test/unittests/test_media_templates.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for ovos_plugin_manager.templates.media."""
+"""Unit tests for ovos_plugin_manager.templates.media (MediaBackend v2)."""
 
+import ast
+import inspect
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from ovos_plugin_manager.templates.media import (
     AudioPlayerBackend,
     MediaBackend,
+    PlaybackEvent,
     RemoteAudioPlayerBackend,
     RemoteVideoPlayerBackend,
     RemoteWebPlayerBackend,
@@ -29,155 +32,40 @@ from ovos_plugin_manager.templates.media import (
 
 
 # ---------------------------------------------------------------------------
-# Concrete subclass helpers
+# Concrete subclass helper
 # ---------------------------------------------------------------------------
 
 class _ConcreteMediaBackend(MediaBackend):
     """Minimal concrete MediaBackend for testing."""
 
     def supported_uris(self):
-        """Return supported URI types."""
         return ["file", "http"]
 
-    def play(self):
-        """No-op play."""
+    def load_track(self, uri: str, metadata: dict = None) -> bool:
+        self.meta.update(metadata or {})
+        return True
 
-    def stop(self):
-        """No-op stop."""
+    def play(self):
+        self.report(PlaybackEvent.TRACK_START)
+
+    def _stop(self) -> bool:
+        self.report_track_end()
+        return True
 
     def pause(self):
-        """No-op pause."""
+        self.report(PlaybackEvent.PAUSED)
 
     def resume(self):
-        """No-op resume."""
-
-    def lower_volume(self):
-        """No-op lower_volume."""
-
-    def restore_volume(self):
-        """No-op restore_volume."""
+        self.report(PlaybackEvent.RESUMED)
 
     def get_track_length(self) -> int:
-        """Return zero track length."""
         return 0
 
     def get_track_position(self) -> int:
-        """Return zero position."""
         return 0
 
-    def set_track_position(self, milliseconds) -> None:
-        """No-op set_track_position."""
-
-
-class _ConcreteAudioBackend(AudioPlayerBackend):
-    """Minimal AudioPlayerBackend for testing."""
-
-    def supported_uris(self):
-        """Return audio URIs."""
-        return ["file"]
-
-    def play(self):
-        """No-op play."""
-
-    def stop(self):
-        """No-op stop."""
-
-    def pause(self):
-        """No-op pause."""
-
-    def resume(self):
-        """No-op resume."""
-
-    def lower_volume(self):
-        """No-op lower_volume."""
-
-    def restore_volume(self):
-        """No-op restore_volume."""
-
-    def get_track_length(self) -> int:
-        """Return zero."""
-        return 0
-
-    def get_track_position(self) -> int:
-        """Return zero."""
-        return 0
-
-    def set_track_position(self, milliseconds) -> None:
-        """No-op."""
-
-
-class _ConcreteVideoBackend(VideoPlayerBackend):
-    """Minimal VideoPlayerBackend for testing."""
-
-    def supported_uris(self):
-        """Return video URIs."""
-        return ["file"]
-
-    def play(self):
-        """No-op play."""
-
-    def stop(self):
-        """No-op stop."""
-
-    def pause(self):
-        """No-op pause."""
-
-    def resume(self):
-        """No-op resume."""
-
-    def lower_volume(self):
-        """No-op lower_volume."""
-
-    def restore_volume(self):
-        """No-op restore_volume."""
-
-    def get_track_length(self) -> int:
-        """Return zero."""
-        return 0
-
-    def get_track_position(self) -> int:
-        """Return zero."""
-        return 0
-
-    def set_track_position(self, milliseconds) -> None:
-        """No-op."""
-
-
-class _ConcreteWebBackend(WebPlayerBackend):
-    """Minimal WebPlayerBackend for testing."""
-
-    def supported_uris(self):
-        """Return web URIs."""
-        return ["http", "https"]
-
-    def play(self):
-        """No-op play."""
-
-    def stop(self):
-        """No-op stop."""
-
-    def pause(self):
-        """No-op pause."""
-
-    def resume(self):
-        """No-op resume."""
-
-    def lower_volume(self):
-        """No-op lower_volume."""
-
-    def restore_volume(self):
-        """No-op restore_volume."""
-
-    def get_track_length(self) -> int:
-        """Return zero."""
-        return 0
-
-    def get_track_position(self) -> int:
-        """Return zero."""
-        return 0
-
-    def set_track_position(self, milliseconds) -> None:
-        """No-op."""
+    def set_track_position(self, milliseconds: int) -> None:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -188,191 +76,438 @@ class TestMediaBackend(unittest.TestCase):
     """Tests for MediaBackend base class."""
 
     def setUp(self) -> None:
-        """Create a concrete backend with a FakeBus."""
-        self.backend: _ConcreteMediaBackend = _ConcreteMediaBackend()
+        self.backend = _ConcreteMediaBackend()
 
     def test_init_defaults(self) -> None:
-        """MediaBackend initialises with default config and bus."""
+        """MediaBackend initialises with default config and a FakeBus."""
+        from ovos_utils.fakebus import FakeBus
         self.assertEqual(self.backend.config, {})
-        self.assertIsNone(self.backend._now_playing)
         self.assertFalse(self.backend.supports_mime_hints)
+        self.assertIsInstance(self.backend.bus, FakeBus)
 
     def test_init_custom_config(self) -> None:
-        """MediaBackend stores provided config."""
         backend = _ConcreteMediaBackend(config={"key": "val"})
         self.assertEqual(backend.config["key"], "val")
 
-    def test_set_track_start_callback(self) -> None:
-        """set_track_start_callback stores the callback."""
-        cb: MagicMock = MagicMock()
-        self.backend.set_track_start_callback(cb)
-        self.assertIs(self.backend._track_start_callback, cb)
+    def test_init_accepts_custom_bus(self) -> None:
+        """bus= is accepted and stored as-is - it is a plugin-private
+        transport, not part of the state contract."""
+        custom_bus = MagicMock()
+        backend = _ConcreteMediaBackend(config={}, bus=custom_bus)
+        self.assertIs(backend.bus, custom_bus)
 
-    def test_load_track(self) -> None:
-        """load_track sets _now_playing and emits media state message."""
-        self.backend.load_track("file:///test.mp3")
-        self.assertEqual(self.backend._now_playing, "file:///test.mp3")
+    def test_bus_is_never_used_for_state_by_default(self) -> None:
+        """Constructing standalone with no bus argument must not touch a
+        real messagebus - the default FakeBus is inert."""
+        backend = _ConcreteMediaBackend()
+        self.assertTrue(hasattr(backend.bus, "emit"))
+
+    def test_load_track_returns_bool(self) -> None:
+        self.assertTrue(self.backend.load_track("file:///test.mp3"))
 
     def test_load_track_with_metadata(self) -> None:
-        """load_track stores metadata."""
         self.backend.load_track("file:///test.mp3", metadata={"title": "Test"})
         self.assertEqual(self.backend.meta["title"], "Test")
 
-    def test_ocp_start(self) -> None:
-        """ocp_start calls play and emits player state."""
-        self.backend._now_playing = "file:///test.mp3"
-        self.backend.ocp_start()  # Should not raise
+    def test_report_noops_without_reporter(self) -> None:
+        """report() must not raise and must not touch anything when unbound."""
+        # mutation check target: if report() silently swallowed events even
+        # when bound (see test_report_delivers_event_to_bound_reporter) this
+        # test alone would not catch it - it only proves the unbound path
+        # is safe, which it is by construction (early return).
+        self.backend.report(PlaybackEvent.TRACK_START, foo="bar")  # no raise
 
-    def test_ocp_error_clears_now_playing(self) -> None:
-        """ocp_error clears _now_playing."""
-        self.backend._now_playing = "file:///test.mp3"
-        self.backend.ocp_error()
-        self.assertIsNone(self.backend._now_playing)
+    def test_bind_event_reporter_delivers_event(self) -> None:
+        """A bound reporter receives the exact event and kwargs reported."""
+        received = []
 
-    def test_ocp_error_when_nothing_playing(self) -> None:
-        """ocp_error does nothing when _now_playing is None."""
-        self.backend._now_playing = None
-        self.backend.ocp_error()  # Should not raise
+        def reporter(event, **data):
+            received.append((event, data))
 
-    def test_ocp_stop_clears_now_playing(self) -> None:
-        """ocp_stop clears _now_playing and calls stop."""
-        self.backend._now_playing = "file:///test.mp3"
-        self.backend.ocp_stop()
-        self.assertIsNone(self.backend._now_playing)
+        self.backend.bind_event_reporter(reporter)
+        self.backend.report(PlaybackEvent.ERROR, error="boom")
 
-    def test_ocp_stop_when_nothing_playing(self) -> None:
-        """ocp_stop does nothing when _now_playing is None."""
-        self.backend._now_playing = None
-        self.backend.ocp_stop()  # Should not raise
+        self.assertEqual(len(received), 1)
+        event, data = received[0]
+        self.assertIs(event, PlaybackEvent.ERROR)
+        self.assertEqual(data, {"error": "boom"})
 
-    def test_ocp_pause(self) -> None:
-        """ocp_pause calls pause and emits state when something is playing."""
-        self.backend._now_playing = "file:///test.mp3"
-        self.backend.ocp_pause()  # Should not raise
+    def test_bind_event_reporter_delivers_via_play(self) -> None:
+        """play() reports TRACK_START through the bound reporter."""
+        reporter = MagicMock()
+        self.backend.bind_event_reporter(reporter)
+        self.backend.play()
+        reporter.assert_called_once_with(PlaybackEvent.TRACK_START)
 
-    def test_ocp_pause_when_nothing_playing(self) -> None:
-        """ocp_pause does nothing when _now_playing is None."""
-        self.backend._now_playing = None
-        self.backend.ocp_pause()  # Should not raise
+    def test_reporter_with_kwargs_signature_receives_any_event(self) -> None:
+        """A reporter declared as (event, **kwargs) - the loosest normative
+        shape - must receive every event/data combination reported,
+        including the uri staleness-check hint on END_OF_MEDIA."""
+        received = []
 
-    def test_ocp_resume(self) -> None:
-        """ocp_resume calls resume when something is playing."""
-        self.backend._now_playing = "file:///test.mp3"
-        self.backend.ocp_resume()  # Should not raise
+        def r(event, **kwargs):
+            received.append((event, kwargs))
 
-    def test_ocp_resume_when_nothing_playing(self) -> None:
-        """ocp_resume does nothing when _now_playing is None."""
-        self.backend._now_playing = None
-        self.backend.ocp_resume()  # Should not raise
+        self.backend.bind_event_reporter(r)
+        self.backend.report(PlaybackEvent.PAUSED)
+        self.backend.report(PlaybackEvent.ERROR, error="disk full")
+        self.backend.report(PlaybackEvent.END_OF_MEDIA, uri="file:///test.mp3")
 
-    def test_playback_time_default(self) -> None:
-        """playback_time returns 0 by default."""
-        self.assertEqual(self.backend.playback_time, 0)
+        self.assertEqual(received, [
+            (PlaybackEvent.PAUSED, {}),
+            (PlaybackEvent.ERROR, {"error": "disk full"}),
+            (PlaybackEvent.END_OF_MEDIA, {"uri": "file:///test.mp3"}),
+        ])
 
-    def test_seek_forward(self) -> None:
-        """seek_forward updates track position."""
-        self.backend.seek_forward(1)  # get_track_position() + 1000ms
+    def test_reporter_with_named_error_kwarg_receives_error_event(self) -> None:
+        """A reporter that only names the keywords it cares about - e.g.
+        (event, error=None) - must still work for PlaybackEvent.ERROR,
+        proving the call convention is positional-event + keyword-data."""
+        received = []
 
-    def test_seek_backward(self) -> None:
-        """seek_backward updates track position."""
-        self.backend.seek_backward(1)  # get_track_position() - 1000ms
+        def r(event, error=None):
+            received.append((event, error))
 
-    def test_track_info(self) -> None:
-        """track_info returns meta dict."""
+        self.backend.bind_event_reporter(r)
+        self.backend.report(PlaybackEvent.ERROR, error="disk full")
+
+        self.assertEqual(received, [(PlaybackEvent.ERROR, "disk full")])
+
+    def test_error_payload_shape_is_normative(self) -> None:
+        """PlaybackEvent.ERROR is always reported with a single 'error'
+        kwarg whose value is a string - pin the documented payload shape."""
+        reporter = MagicMock()
+        self.backend.bind_event_reporter(reporter)
+
+        try:
+            raise RuntimeError("player crashed")
+        except RuntimeError as exc:
+            self.backend.report(PlaybackEvent.ERROR, error=str(exc))
+
+        reporter.assert_called_once_with(PlaybackEvent.ERROR, error="player crashed")
+        _, kwargs = reporter.call_args
+        self.assertEqual(set(kwargs), {"error"})
+        self.assertIsInstance(kwargs["error"], str)
+
+    def test_capability_defaults(self) -> None:
+        self.assertFalse(MediaBackend.can_seek)
+        self.assertTrue(MediaBackend.can_pause)
+        self.assertFalse(MediaBackend.is_remote)
+
+    def test_lower_and_restore_volume_default_noop(self) -> None:
+        """Default volume duck hooks exist and do nothing when unimplemented."""
+        self.backend.lower_volume()
+        self.backend.restore_volume()  # no raise, no override needed
+
+    def test_track_info_default_empty(self) -> None:
+        fresh = _ConcreteMediaBackend()
+        self.assertEqual(fresh.track_info(), {})
+
+    def test_track_info_returns_meta(self) -> None:
         self.backend.meta = {"artist": "Test Artist"}
-        info = self.backend.track_info()
-        self.assertEqual(info["artist"], "Test Artist")
+        self.assertEqual(self.backend.track_info()["artist"], "Test Artist")
 
-    def test_shutdown(self) -> None:
-        """shutdown calls stop without error."""
-        self.backend._now_playing = "file:///test.mp3"
-        self.backend.shutdown()  # Should call stop
+    def test_shutdown_calls_stop(self) -> None:
+        reporter = MagicMock()
+        self.backend.bind_event_reporter(reporter)
+        self.backend.shutdown()
+        reporter.assert_called_once_with(PlaybackEvent.STOPPED, uri=None)
+
+    def test_no_deleted_v1_verbs(self) -> None:
+        """v1 bus-coupled verbs must not survive on the v2 template."""
+        for name in ("ocp_start", "ocp_stop", "ocp_pause", "ocp_resume",
+                     "ocp_error", "set_track_start_callback",
+                     "seek_forward", "seek_backward"):
+            self.assertFalse(hasattr(MediaBackend, name),
+                              f"{name} should have been removed in v2")
+
+    def test_stop_is_concrete_and_underscore_stop_is_abstract(self) -> None:
+        """stop() is now the concrete template method; _stop() is what
+        plugins must implement."""
+        self.assertNotIn("stop", MediaBackend.__abstractmethods__)
+        self.assertIn("stop", dir(MediaBackend))
+        self.assertFalse(getattr(MediaBackend.stop, "__isabstractmethod__", False))
+        self.assertIn("_stop", MediaBackend.__abstractmethods__)
+
+    def test_abstract_verbs_cannot_be_instantiated_without_them(self) -> None:
+        """Omitting an abstract verb must prevent instantiation."""
+        class _Incomplete(MediaBackend):
+            def supported_uris(self):
+                return []
+
+            def load_track(self, uri, metadata=None):
+                return True
+
+            def play(self):
+                pass
+
+            def _stop(self):
+                return True
+
+            def pause(self):
+                pass
+
+            # resume deliberately missing - get/set_track_position are
+            # concrete defaults in v2 (see test_position_trio_concrete_defaults)
+            # and must NOT be required here.
+
+        with self.assertRaises(TypeError):
+            _Incomplete()
+
+    def test_position_trio_concrete_defaults(self) -> None:
+        """get_track_length/get_track_position/set_track_position are
+        concrete on the base class: -1 (unknown) for the getters, a no-op
+        for the setter, since can_seek defaults to False."""
+        class _NoSeek(MediaBackend):
+            def supported_uris(self):
+                return []
+
+            def load_track(self, uri, metadata=None):
+                return True
+
+            def play(self):
+                pass
+
+            def _stop(self):
+                return True
+
+            def pause(self):
+                pass
+
+            def resume(self):
+                pass
+            # get_track_length/get_track_position/set_track_position NOT overridden
+
+        backend = _NoSeek()
+        self.assertFalse(backend.can_seek)
+        self.assertEqual(backend.get_track_length(), -1)
+        self.assertEqual(backend.get_track_position(), -1)
+        backend.set_track_position(5000)  # no-op, must not raise
+
+    def test_stop_sets_flag_before_delegating_to_stop_impl(self) -> None:
+        """Concrete stop() must set _stop_requested=True BEFORE calling
+        _stop(), so a backend's _stop() implementation - or anything it
+        triggers synchronously - can already see the flag as True."""
+        seen_flag_during_stop = []
+
+        class _RecordingStop(MediaBackend):
+            def supported_uris(self):
+                return []
+
+            def load_track(self, uri, metadata=None):
+                return True
+
+            def play(self):
+                pass
+
+            def _stop(self):
+                seen_flag_during_stop.append(self._stop_requested)
+                return True
+
+            def pause(self):
+                pass
+
+            def resume(self):
+                pass
+
+        backend = _RecordingStop()
+        self.assertFalse(backend._stop_requested)
+        backend.stop()
+        self.assertEqual(seen_flag_during_stop, [True])
+
+    def test_report_track_end_maps_error(self) -> None:
+        """report_track_end(error=...) reports ERROR with a stringified
+        error and the given uri, regardless of _stop_requested."""
+        reporter = MagicMock()
+        self.backend.bind_event_reporter(reporter)
+        self.backend._stop_requested = True  # must not win over error
+
+        self.backend.report_track_end(uri="file:///bad.mp3", error=RuntimeError("nonzero exit"))
+
+        reporter.assert_called_once_with(PlaybackEvent.ERROR, error="nonzero exit", uri="file:///bad.mp3")
+
+    def test_report_track_end_maps_stopped_when_explicit_stop_requested(self) -> None:
+        """report_track_end() with no error, after stop() was called,
+        reports STOPPED."""
+        reporter = MagicMock()
+        self.backend.bind_event_reporter(reporter)
+        self.backend.stop()  # sets _stop_requested via the real _stop()
+        reporter.reset_mock()  # ignore whatever _stop()'s own report did
+
+        self.backend._stop_requested = True  # simulate an exit callback firing later
+        self.backend.report_track_end(uri="file:///test.mp3")
+
+        reporter.assert_called_once_with(PlaybackEvent.STOPPED, uri="file:///test.mp3")
+
+    def test_report_track_end_maps_end_of_media_by_default(self) -> None:
+        """report_track_end() with no error and no prior stop() reports
+        END_OF_MEDIA - a natural end."""
+        reporter = MagicMock()
+        self.backend.bind_event_reporter(reporter)
+        self.assertFalse(self.backend._stop_requested)
+
+        self.backend.report_track_end(uri="file:///test.mp3")
+
+        reporter.assert_called_once_with(PlaybackEvent.END_OF_MEDIA, uri="file:///test.mp3")
+
+    def test_report_track_end_always_clears_stop_requested_flag(self) -> None:
+        """Whichever branch report_track_end takes, _stop_requested must
+        end up False, so a stale flag can't leak into the next track."""
+        # error branch
+        self.backend._stop_requested = True
+        self.backend.report_track_end(error=RuntimeError("boom"))
+        self.assertFalse(self.backend._stop_requested)
+
+        # stopped branch
+        self.backend._stop_requested = True
+        self.backend.report_track_end()
+        self.assertFalse(self.backend._stop_requested)
+
+        # end-of-media branch (flag already False, must remain False)
+        self.backend.report_track_end()
+        self.assertFalse(self.backend._stop_requested)
+
+    def test_seekable_backend_overrides_position_trio(self) -> None:
+        """A backend that supports seeking overrides all three and sets
+        can_seek=True; the default -1/no-op behaviour must not leak through."""
+        class _Seekable(MediaBackend):
+            can_seek = True
+
+            def __init__(self, config=None):
+                super().__init__(config)
+                self._pos = 0
+
+            def supported_uris(self):
+                return []
+
+            def load_track(self, uri, metadata=None):
+                return True
+
+            def play(self):
+                pass
+
+            def _stop(self):
+                return True
+
+            def pause(self):
+                pass
+
+            def resume(self):
+                pass
+
+            def get_track_length(self):
+                return 60000
+
+            def get_track_position(self):
+                return self._pos
+
+            def set_track_position(self, milliseconds):
+                self._pos = milliseconds
+
+        backend = _Seekable()
+        self.assertTrue(backend.can_seek)
+        self.assertEqual(backend.get_track_length(), 60000)
+        backend.set_track_position(1234)
+        self.assertEqual(backend.get_track_position(), 1234)
+
+
+class _RecordingBus:
+    """Minimal FakeBus-shaped stand-in that records every emit() call, so
+    tests can assert on exactly what a backend puts on its bus."""
+
+    def __init__(self):
+        self.emitted = []
+
+    def emit(self, message):
+        self.emitted.append(message)
+
+    def on(self, *args, **kwargs):
+        pass
+
+    def remove(self, *args, **kwargs):
+        pass
+
+
+class TestNoStateEmission(unittest.TestCase):
+    """The template must never emit ovos.common_play.* state itself - state
+    flows exclusively through report()/bind_event_reporter(); the bus is a
+    plugin-private transport for non-state concerns only."""
+
+    def test_module_source_has_no_bus_emit_call(self) -> None:
+        """The template must not call bus.emit() anywhere in its code - the
+        only way it could put an ovos.common_play.* state message on the
+        wire is through that call, and it must not exist at all."""
+        import ovos_plugin_manager.templates.media as media_mod
+        tree = ast.parse(inspect.getsource(media_mod))
+        emit_calls = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "emit"
+        ]
+        self.assertEqual(emit_calls, [])
+
+    def test_driving_backend_through_full_lifecycle_emits_no_bus_messages(self) -> None:
+        """play/pause/resume/stop/shutdown, exercised end to end with a
+        recording bus attached, must produce zero bus.emit() calls - all
+        state must flow through the bound event reporter instead."""
+        bus = _RecordingBus()
+        reporter = MagicMock()
+        backend = _ConcreteMediaBackend(bus=bus)
+        backend.bind_event_reporter(reporter)
+
+        backend.load_track("file:///test.mp3")
+        backend.play()
+        backend.pause()
+        backend.resume()
+        backend.stop()
+        backend.shutdown()
+
+        self.assertEqual(bus.emitted, [])
+        # the same lifecycle must still reach the daemon via report()
+        self.assertGreater(reporter.call_count, 0)
+
+    def test_standalone_construction_with_no_bus_argument_is_safe(self) -> None:
+        """bus=None (the default) must not touch a real messagebus and
+        must still support the full lifecycle without raising."""
+        backend = _ConcreteMediaBackend()
+        backend.load_track("file:///test.mp3")
+        backend.play()
+        backend.stop()  # no raise, no reporter bound either
 
 
 # ---------------------------------------------------------------------------
-# Tests for AudioPlayerBackend
+# Family marker classes
 # ---------------------------------------------------------------------------
 
-class TestAudioPlayerBackend(unittest.TestCase):
-    """Tests for AudioPlayerBackend subclass."""
+class TestFamilyMarkers(unittest.TestCase):
+    """AudioPlayerBackend/VideoPlayerBackend/WebPlayerBackend are thin markers."""
 
-    def setUp(self) -> None:
-        """Create a concrete audio backend."""
-        self.backend: _ConcreteAudioBackend = _ConcreteAudioBackend()
+    def test_audio_player_backend_is_media_backend(self) -> None:
+        self.assertTrue(issubclass(AudioPlayerBackend, MediaBackend))
 
-    def test_load_track_emits_queued_audio(self) -> None:
-        """load_track emits QUEUED_AUDIO track state."""
-        self.backend.load_track("file:///test.mp3")
-        self.assertEqual(self.backend._now_playing, "file:///test.mp3")
+    def test_video_player_backend_is_media_backend(self) -> None:
+        self.assertTrue(issubclass(VideoPlayerBackend, MediaBackend))
 
-    def test_ocp_start_emits_playing_audio(self) -> None:
-        """ocp_start emits PLAYING_AUDIO track state."""
-        self.backend._now_playing = "file:///test.mp3"
-        self.backend.ocp_start()  # Should not raise
+    def test_web_player_backend_is_media_backend(self) -> None:
+        self.assertTrue(issubclass(WebPlayerBackend, MediaBackend))
 
-
-# ---------------------------------------------------------------------------
-# Tests for VideoPlayerBackend
-# ---------------------------------------------------------------------------
-
-class TestVideoPlayerBackend(unittest.TestCase):
-    """Tests for VideoPlayerBackend subclass."""
-
-    def setUp(self) -> None:
-        """Create a concrete video backend."""
-        self.backend: _ConcreteVideoBackend = _ConcreteVideoBackend()
-
-    def test_load_track_emits_queued_video(self) -> None:
-        """load_track emits QUEUED_VIDEO track state."""
-        self.backend.load_track("file:///test.mp4")
-        self.assertEqual(self.backend._now_playing, "file:///test.mp4")
-
-    def test_ocp_start_emits_playing_video(self) -> None:
-        """ocp_start emits PLAYING_VIDEO track state."""
-        self.backend._now_playing = "file:///test.mp4"
-        self.backend.ocp_start()  # Should not raise
-
-
-# ---------------------------------------------------------------------------
-# Tests for WebPlayerBackend
-# ---------------------------------------------------------------------------
-
-class TestWebPlayerBackend(unittest.TestCase):
-    """Tests for WebPlayerBackend subclass."""
-
-    def setUp(self) -> None:
-        """Create a concrete web backend."""
-        self.backend: _ConcreteWebBackend = _ConcreteWebBackend()
-
-    def test_load_track_emits_queued_webview(self) -> None:
-        """load_track emits QUEUED_WEBVIEW track state."""
-        self.backend.load_track("https://example.com")
-        self.assertEqual(self.backend._now_playing, "https://example.com")
-
-    def test_ocp_start_emits_playing_webview(self) -> None:
-        """ocp_start emits PLAYING_WEBVIEW track state."""
-        self.backend._now_playing = "https://example.com"
-        self.backend.ocp_start()  # Should not raise
-
-
-# ---------------------------------------------------------------------------
-# Tests for Remote variants (smoke tests for instantiation)
-# ---------------------------------------------------------------------------
-
-class TestRemoteBackends(unittest.TestCase):
-    """Smoke tests for remote backend subclasses."""
-
-    def test_remote_audio_is_audio_backend(self) -> None:
-        """RemoteAudioPlayerBackend inherits from AudioPlayerBackend."""
+    def test_remote_audio_is_audio_backend_and_remote(self) -> None:
         self.assertTrue(issubclass(RemoteAudioPlayerBackend, AudioPlayerBackend))
+        self.assertTrue(RemoteAudioPlayerBackend.is_remote)
 
-    def test_remote_video_is_video_backend(self) -> None:
-        """RemoteVideoPlayerBackend inherits from VideoPlayerBackend."""
+    def test_remote_video_is_video_backend_and_remote(self) -> None:
         self.assertTrue(issubclass(RemoteVideoPlayerBackend, VideoPlayerBackend))
+        self.assertTrue(RemoteVideoPlayerBackend.is_remote)
 
-    def test_remote_web_is_web_backend(self) -> None:
-        """RemoteWebPlayerBackend inherits from WebPlayerBackend."""
+    def test_remote_web_is_web_backend_and_remote(self) -> None:
         self.assertTrue(issubclass(RemoteWebPlayerBackend, WebPlayerBackend))
+        self.assertTrue(RemoteWebPlayerBackend.is_remote)
+
+    def test_non_remote_defaults_false(self) -> None:
+        self.assertFalse(AudioPlayerBackend.is_remote)
+        self.assertFalse(VideoPlayerBackend.is_remote)
+        self.assertFalse(WebPlayerBackend.is_remote)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

MediaBackend plugins currently emit their own wire messages. `ocp_start`, `ocp_stop`, `ocp_pause`, `ocp_resume`, and `ocp_error` each push `ovos.common_play.{player,media,track}.state` Messages directly onto the bus, and ovos-media's `BaseMediaService` subscribes to those same messages (`handle_media_state_change`) to learn what its own plugin is doing. Plugin behavior and daemon state ownership end up mixed together, message ordering becomes bus-dependent, and the LOADED_MEDIA re-entry bug class follows directly from a plugin driving state transitions it shouldn't own.

This PR rewrites `ovos_plugin_manager/templates/media.py` to split the two concerns cleanly. The bus stays on the template - `__init__(self, config=None, bus=None)` still accepts a `MessageBusClient`, defaulting to a `FakeBus` (from `ovos_utils.fakebus`, not `ovos_bus_client`) when none is given - but it is now strictly a plugin-private transport for non-state concerns: ecosystem integration, discovery protocols, anything a specific plugin needs the bus for on its own terms. It is never a state channel again. All playback state instead flows through a single reporting contract: a plugin reports what physically happened inside the player process - a track actually started, playback actually paused/resumed/stopped, the media actually ended, or the player errored - through a `PlaybackEvent` enum delivered via `bind_event_reporter(callback)` / `self.report(event, **data)`. The daemon that owns the plugin binds the reporter and is the only thing that turns a physical event into a wire message or a state-machine transition, including the LOADED_MEDIA transition, which is not a `PlaybackEvent` at all - it's the daemon's own bookkeeping on `load_track()` returning `True`, because there's no physical event to observe when a track is merely loaded rather than played. A backend that emits any `ovos.common_play.*` message itself is buggy by definition under this contract; the daemon owns that wire exclusively.

The reporter's call convention is now stated once, normatively, in both the docstring and the type hint: `reporter(event, **data)` - a `PlaybackEvent` positionally, followed by event-specific data as keywords. The annotation is `Callable[..., None]` rather than the narrower (and previously wrong) `Callable[[PlaybackEvent, dict], None]`, since a reporter may declare `**kwargs` to accept anything or name only the specific keyword it cares about (e.g. `def on_event(event, error=None)`), and both shapes are exercised in tests. `PlaybackEvent.ERROR`'s payload shape is pinned as normative too: always `report(PlaybackEvent.ERROR, error=str(exc))`, a single `error` keyword holding a string.

`report()` no-ops safely (with a debug log) when no reporter has been bound, so a backend can be constructed and exercised standalone - in tests, or by any code that doesn't need a daemon attached - without special-casing. Seeking becomes a uniform absolute-position API in milliseconds. `get_track_length`, `get_track_position`, and `set_track_position` are now concrete on the base class rather than abstract: the getters default to `-1` (unknown) and the setter is a no-op with a debug log, all documented as only meaningful once a backend sets `can_seek = True` and overrides all three - which keeps the base class honestly instantiable for the common case of a backend that doesn't support seeking at all, instead of forcing every plugin to hand-write a stub. The old relative `seek_forward`/`seek_backward` helpers are gone because the daemon now computes the absolute target itself. `set_track_start_callback` and all `ocp_*` methods are deleted outright. Volume ducking hooks (`lower_volume`/`restore_volume`) get safe no-op defaults instead of being abstract. Three class attributes - `can_seek` (default False), `can_pause` (default True), `is_remote` (default False) - replace behavior that used to live in subclass overrides; the `AudioPlayerBackend`/`VideoPlayerBackend`/`WebPlayerBackend` family classes and their `Remote*` counterparts are now thin markers with no logic of their own, since there's nothing left to override once state emission moves out of the template. The `Remote*` class names are preserved unchanged because ovos-media's `available_backends` still isinstance-checks them; `is_remote` is offered as the forward-looking replacement for that check.

This is a deliberate breaking change with no backcompat shim. ovos-media is the only daemon consumer of this template and is pre-alpha with no external users, so there is nothing to migrate live and no reason to carry v1 methods forward. `ovos_plugin_manager/templates/audio.py`, which the legacy ovos-audio stack still uses, is untouched.

Migration for plugin authors porting from v1, including the two shipped consumers of this template (ovos-media-plugin-vlc and ovos-media-plugin-mass):

| v1 | v2 |
|---|---|
| `__init__(self, config=None, bus=None)` | unchanged signature; `bus` is now documented as plugin-private transport only, never a state channel |
| `self._now_playing` (instance attribute) | gone; the daemon owns now-playing bookkeeping. A plugin that needs the current uri for its own purposes keeps its own attribute, it just no longer drives any bus state off it |
| `self._track_start_callback` / `set_track_start_callback(cb)` | gone; daemon calls `bind_event_reporter(cb)` once, plugin calls `self.report(PlaybackEvent.TRACK_START)` when playback actually starts |
| `ocp_start()` | daemon calls `play()` directly; plugin reports `TRACK_START` when it actually starts |
| `ocp_stop()` | daemon calls `stop()` directly; plugin reports `STOPPED`/`END_OF_MEDIA` |
| overriding `stop()` | implement `_stop()` instead. The base `stop()` is now concrete: it records that a stop was explicitly requested, then delegates to `_stop()` for the actual work |
| ad-hoc "was this an explicit stop or a natural end?" flags hand-rolled in an exit/status callback | `self.report_track_end(uri=..., error=...)` - the base class now owns this disambiguation. Call it from a subprocess exit handler or an MPRIS `Stopped` transition and it reports `ERROR` (if `error` is given), `STOPPED` (if `stop()` was called since the last report), or `END_OF_MEDIA` (otherwise), then always clears the flag |
| `ocp_pause()` / `ocp_resume()` | daemon calls `pause()`/`resume()` directly; plugin reports `PAUSED`/`RESUMED` |
| `ocp_error()` | plugin reports `PlaybackEvent.ERROR, error=str(...)` |
| any `self.bus.emit(...)` of an `ovos.common_play.*` state message | forbidden; state goes through `report()` only. This is the one row that used to read as a blanket mapping and it overpromised - it's not "swap the emit for a report call" everywhere, it's "delete the plugin's own opinion about state entirely". For `END_OF_MEDIA` and `ERROR` specifically, also attach the track's `uri`: `self.report(PlaybackEvent.END_OF_MEDIA, uri=<the uri load_track received>)`, so the daemon can drop a stale event from a previous track's watcher thread firing after a new track has already loaded - an event reported without `uri` cannot be staleness-checked |
| `seek_forward(seconds)` / `seek_backward(seconds)` | daemon computes absolute ms and calls `set_track_position(ms)`; a non-seeking backend can leave the base class's no-op default in place |
| `MediaState.LOADED_MEDIA` bus emission on load | daemon transitions state itself when `load_track()` returns `True` |
| vlc's periodic `ovos.common_play.playback_time` timer emission | **no v2 event, deliberately** - the daemon polls `get_track_position()` itself; delete the plugin's polling timer entirely on port, don't replace it with a report call |
| mass's `ovos.mass.ping` discovery subscription | **unchanged** - this is exactly the kind of plugin-private, non-state protocol `self.bus` still exists for. It stays a bus subscription; it was never state and doesn't move to `report()` |

I verified the defect against the current `dev` source in both repos: `ovos_plugin_manager/templates/media.py` (the file being rewritten here) and, read-only for reference, `ovos_media/media_backends/base.py` in the ovos-media checkout, which does subscribe to `ovos.common_play.media.state` in `handle_media_state_change` and does isinstance-check the `Remote*` class names in `available_backends`.

Test coverage in `test/unittests/test_media_templates.py` was rewritten for the v2 contract: standalone construction with a default `FakeBus` and with no reporter bound, `bind_event_reporter` delivering the exact event and kwargs to reporters of both shapes (`**kwargs` and a named `error=None` keyword), the `PlaybackEvent.ERROR` payload shape, capability class-attribute defaults, the concrete `-1`/no-op position-trio defaults versus a seekable override, enforcement that the still-abstract verbs must be implemented before instantiation, and - replacing the earlier "no bus import" tests, which stopped making sense once the bus came back - an AST-level check that the module contains no `bus.emit(...)` call anywhere in its code, plus an end-to-end test that drives a concrete backend with a bus attached and a reporter bound through its full lifecycle (load/play/pause/resume/stop/shutdown) and asserts zero bus emissions while confirming state still reaches the daemon via the reporter. I mutation-proofed the load-bearing tests: gutting `report()` to unconditionally no-op even when bound failed both reporter-delivery tests as expected; dropping `**data` from the forwarded call failed the kwargs-signature, named-keyword, and error-payload tests as expected; adding a `bus.emit(...)` call inside the lifecycle test's own concrete backend failed the full-lifecycle no-emission test as expected. All were restored and rerun green.

A retrospective on the nine ported plugin drafts (ffplay, cli, mpris, spotify, vlc, mass, and three more) and live validation surfaced two related gaps this PR closes. Four of the nine independently hand-rolled their own "was this stop explicit or did the track just end?" flag to disambiguate a single exit/status callback, because subprocess exit and MPRIS `Stopped` transitions both look identical from the outside - the plugin has no way to tell "I asked for this" from "it just happened" without tracking it itself. And live validation caught a worse failure mode from the same root cause: a plugin playing a nonexistent file read the player subprocess's failure exit as an ordinary end-of-stream, so a playback failure was reported to the daemon as a normal, successful, unusually short play.

Both are now handled once, on the base class, instead of nine times independently and inconsistently. `stop()` is concrete: it records that a stop was explicitly requested (`self._stop_requested = True`) and delegates to a new abstract `_stop()`, which is what plugins implement now. A new concrete helper, `report_track_end(uri=None, error=None)`, is the one correct way to report the end of a track from a callback that can't itself tell a requested stop from a natural end: pass `error` and it reports `ERROR`; otherwise, if `stop()` was called since the last report, it reports `STOPPED`; otherwise `END_OF_MEDIA`. It always clears the flag afterward regardless of which branch ran, so a stale flag can't leak into the next track. Critically, a nonzero subprocess exit code or an engine-reported failure MUST be passed as `error` - it must never be silently mapped to a natural end just because the process exited, which is exactly the bug live validation caught.

Three short paragraphs were added to the class docstring, in the same normative register as the existing `uri`-provenance guidance, aimed at the two backend shapes that actually hit this: subprocess-shaped backends must check the return code before calling `report_track_end`, since a crashed player and a cleanly finished one both just "exit"; remote/side-channel backends (Cast, MPRIS, network players) should keep their verb methods as pure asks with zero `report()` calls of their own, leaving the status listener or poller as the sole reporter of what the remote device actually did, so a pause triggered from the device's own app still surfaces correctly; and external-state detection may be event-driven (preferred, where the remote SDK offers signals or listeners) or polled state-diffing (acceptable, comparing against the last seen state and reporting only the transition).

Test coverage in `test/unittests/test_media_templates.py` was rewritten for the v2 contract: standalone construction with a default `FakeBus` and with no reporter bound, `bind_event_reporter` delivering the exact event and kwargs to reporters of both shapes (`**kwargs` and a named `error=None` keyword), the `PlaybackEvent.ERROR` payload shape, capability class-attribute defaults, the concrete `-1`/no-op position-trio defaults versus a seekable override, enforcement that the still-abstract verbs must be implemented before instantiation (now `_stop` rather than `stop`, which is concrete), and - replacing the earlier "no bus import" tests, which stopped making sense once the bus came back - an AST-level check that the module contains no `bus.emit(...)` call anywhere in its code, plus an end-to-end test that drives a concrete backend with a bus attached and a reporter bound through its full lifecycle (load/play/pause/resume/stop/shutdown) and asserts zero bus emissions while confirming state still reaches the daemon via the reporter. `report_track_end` is covered for all three mappings, for clearing the flag in every branch, and for the `stop()`→`_stop()` delegation ordering (a recording `_stop()` observes `_stop_requested` already `True` when it runs). I mutation-proofed the load-bearing tests: gutting `report()` to unconditionally no-op even when bound failed both reporter-delivery tests as expected; dropping `**data` from the forwarded call failed the kwargs-signature, named-keyword, and error-payload tests as expected; adding a `bus.emit(...)` call inside the lifecycle test's own concrete backend failed the full-lifecycle no-emission test as expected; inverting the `_stop_requested` branch in `report_track_end` failed both the `STOPPED` and `END_OF_MEDIA` mapping tests as expected; swapping the order of the flag-set and the `_stop()` call in `stop()` failed the delegation-ordering test as expected. All were restored and rerun green.

Full test suite, fresh capped venv (`python3 -m venv` + `pip install -e ".[test,media]"`, single-worker, `nice -n 19 ionice -c3 taskset -c 0,1`): a clean venv built with `pip` alone resolves `ovos-color-parser` to `0.11.0`, a version that is broken on PyPI itself (`ModuleNotFoundError: No module named 'ovos_color_parser.core'` - the package ships without the `core` module its own `__init__.py` imports), causing spurious `test_hardware.py` failures unrelated to any content in this PR. `uv.lock` pins `ovos-color-parser==0.0.8`, which works, so every recount in this PR installs that pin explicitly. On unmodified `dev`, cloned fresh to a separate directory (not `git stash`, which is banned for baselines - a stash on a shared worktree can revert someone else's uncommitted work): 1152 passed, 0 failed, 0 skipped. On this branch, same fresh-venv method: 1161 passed, 0 failed, 0 skipped. The delta reconciles exactly across this PR's full history: `test_media_templates.py` had 28 tests before this PR, 31 after the prior round (1152 − 28 + 31 = 1155, confirmed then), and 37 now with this round's six new tests (`report_track_end` × 3 mappings, flag-clearing, delegation ordering, and the `stop`/`_stop` abstractness split) - 1155 + 6 = 1161. Every other test in the suite is untouched and its outcome is unchanged throughout.

The nine plugin-port drafts (ffplay, cli, mpris, spotify, vlc, mass, and the rest) will be migrated to `_stop`/`report_track_end` in a follow-up round after this lands. One thing worth flagging for that migration: a plugin that currently reports `STOPPED` from inside its own `stop()` override (rather than from an exit callback) should just delete that report entirely once it moves to `_stop()` - the base `stop()` no longer reports anything itself, so a plugin relying on `report_track_end` for its stop-vs-end disambiguation only needs to call it from the exit/status callback, not from `_stop()` too, or the daemon will see it twice for an explicit stop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Media playback integrations now use standardized events for track start, pause, resume, stop, completion, and errors.
  - Playback state reporting uses a plugin-private event mechanism instead of direct bus messages.
  - Media backends now expose consistent capability indicators for pausing, seeking, and remote playback.
  - Default behavior is provided for unsupported volume, position, and duration operations.
  - Legacy playback callbacks, direct state-emission methods, and forward/backward seeking methods have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->