### PR TITLE
Remove unused suppress_activation field from IntentHandlerMatch

### DIFF
--- a/ovos_plugin_manager/templates/pipeline.py
+++ b/ovos_plugin_manager/templates/pipeline.py
@@ -18,18 +18,12 @@ class IntentHandlerMatch:
         match_data (Optional[Dict]): Additional data provided by the intent match.
         skill_id (Optional[str]): The skill this handler belongs to.
         utterance (Optional[str]): The original utterance triggering the intent.
-        suppress_activation (bool): When True the orchestrator dispatches the
-            match without activating ``skill_id`` (no ``{skill_id}.activate``).
-            A termination or continuation of an already-active skill's
-            participation — e.g. a stop — sets this, since it must not register
-            the target as a freshly activated skill.
     """
     match_type: str
     match_data: Optional[Dict] = None
     skill_id: Optional[str] = None
     utterance: Optional[str] = None
     updated_session: Optional[Session] = None
-    suppress_activation: bool = False
 
 
 class PipelinePlugin:

--- a/test/unittests/test_pipeline.py
+++ b/test/unittests/test_pipeline.py
@@ -297,13 +297,15 @@ class TestOVOSPipelineFactory(unittest.TestCase):
 
 
 class TestIntentHandlerMatchFields(unittest.TestCase):
-    def test_suppress_activation_defaults_false(self):
+    def test_suppress_activation_field_removed(self):
         from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
         m = IntentHandlerMatch(match_type="x:intent", skill_id="x")
-        self.assertFalse(m.suppress_activation)
+        # Field should not exist after removal
+        self.assertFalse(hasattr(m, 'suppress_activation'))
 
-    def test_suppress_activation_settable(self):
+    def test_construct_without_suppress_activation(self):
         from ovos_plugin_manager.templates.pipeline import IntentHandlerMatch
-        m = IntentHandlerMatch(match_type="x:stop", skill_id="x",
-                               suppress_activation=True)
-        self.assertTrue(m.suppress_activation)
+        # Should be able to construct IntentHandlerMatch without suppress_activation
+        m = IntentHandlerMatch(match_type="x:stop", skill_id="x")
+        self.assertEqual(m.match_type, "x:stop")
+        self.assertEqual(m.skill_id, "x")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Haiku 4.5 (claude-haiku-4-5-20251001) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS-PIPELINE-1 §7.3 specifies that activation suppression is keyed on the Match's intent_name and registry row, never on a plugin-declared flag. The suppress_activation field in IntentHandlerMatch was an invention (ovos-core#802) and is no longer read by ovos-core (ovos-core#932).

A comprehensive grep of the OpenVoiceOS organization found no shipped plugins setting this field—only its definition and test code in ovos-plugin-manager itself. With zero producers in the ecosystem, the field is removed entirely along with its docstring. Tests verify both that IntentHandlerMatch can be constructed without it and that the field no longer exists on instances.